### PR TITLE
Remove reference to api/v1

### DIFF
--- a/docs/self_hosting/release_notes.mdx
+++ b/docs/self_hosting/release_notes.mdx
@@ -17,16 +17,16 @@ LangSmith 0.4 improves performance and reliability, implements a new asynchronou
 
 - This release adds an API key salt parameter. This previously defaulted to your LangSmith License Key. **For updates from earlier versions you should set this parameter to your license key to ensure backwards compatibility.** Using a new api key salt will invalidate all existing api keys.
 
+### Performance and Reliability Changes
+
+- Implemented a new asynchronous queue worker and cached token encodings to improve performance when ingesting traces, reducing the delay between ingest and display in the LangSmith UI.
+
 ### Infrastructure changes
 
 - Some our image repositories have been updated. You can see the root repositories in our `values.yaml` file and may need to update mirrors to pick up the new images.
 - Clickhouse persistence now uses 50Gi of storage by default. You can adjust this by changing the `clickhouse.statefulSet.persistence.size` value in your `values.yaml` file.
     - If your existing configuration cannot support 50Gi, you may need to resize your existing storage class or set `clickhouse.statefulSet.persistence.size` to the previous default value of `8Gi`.
 - Consolidation of hubBackend and backend services. We now use one service to serve both of these endpoints. This should not impact your application.
-
-### Performance and Reliability Changes
-
-- Implemented a new asynchronous queue worker and cached token encodings to improve performance when ingesting traces, reducing the delay between ingest and display in the LangSmith UI.
 
 ### Admin changes
 

--- a/docs/self_hosting/release_notes.mdx
+++ b/docs/self_hosting/release_notes.mdx
@@ -6,7 +6,7 @@ sidebar_position: 4
 # LangSmith Release Notes
 
 :::note
-If you are upgrading directly from LangSmith v0.1.x and you wish to retain access to run data in the Langsmith UI after updating, you must first update to v0.2.x and perform a data migration. **Updating directly from v0.1.x to v0.3.x or later will result in data loss as the `runs` table in postgres will be dropped when deploying LangSmith v0.3.x or higher.**  Details are available at https://github.com/langchain-ai/helm/blob/main/charts/langsmith/docs/UPGRADE-0.2.x.md
+If you are updating directly from LangSmith v0.1.x and you wish to retain access to run data in the Langsmith UI after updating, you must first update to v0.2.x and perform a data migration. **Updating directly from v0.1.x to v0.3.x or later will result in data loss as the `runs` table in postgres will be dropped when deploying LangSmith v0.3.x or higher.**  Details are available at https://github.com/langchain-ai/helm/blob/main/charts/langsmith/docs/UPGRADE-0.2.x.md
 :::
 
 ## Week of March 25, 2024 - LangSmith v0.4
@@ -16,14 +16,12 @@ LangSmith 0.4 improves performance and reliability, implements a new asynchronou
 ### Breaking changes
 
 - This release adds an API key salt parameter. This previously defaulted to your LangSmith License Key. **For updates from earlier versions you should set this parameter to your license key to ensure backwards compatibility.** Using a new api key salt will invalidate all existing api keys.
-- If you are migrating from LangSmith version v0.1.x, you must first update to v0.2.x prior to updating to ensure retention of 
 
 ### Infrastructure changes
 
 - Some our image repositories have been updated. You can see the root repositories in our `values.yaml` file and may need to update mirrors to pick up the new images.
 - Clickhouse persistence now uses 50Gi of storage by default. You can adjust this by changing the `clickhouse.statefulSet.persistence.size` value in your `values.yaml` file.
     - If your existing configuration cannot support 50Gi, you may need to resize your existing storage class or set `clickhouse.statefulSet.persistence.size` to the previous default value of `8Gi`.
-- The default URL path is now `/api/v1`
 - Consolidation of hubBackend and backend services. We now use one service to serve both of these endpoints. This should not impact your application.
 
 ### Performance and Reliability Changes


### PR DESCRIPTION
Fix premature reference to api/v1 in default path and remove a fragment.