### PR TITLE
fix: small typos

### DIFF
--- a/docs/evaluation/faq/evaluator-implementations.mdx
+++ b/docs/evaluation/faq/evaluator-implementations.mdx
@@ -100,6 +100,7 @@ evaluate(
   ]}
   groupId="client-language"
 />
+
 ## Criteria with labels
 Your dataset may have ground truth labels or contextual information demonstrating an output that satisfies a criterion or prediction for a certain input. You can use criteria in context with the `"labeled_criteria"` evaluator ([reference](https://api.python.langchain.com/en/latest/evaluation/langchain.evaluation.criteria.eval_chain.LabeledCriteriaEvalChain.html)).
 <CodeTabs
@@ -176,6 +177,7 @@ evaluate(
   ]}
   groupId="client-language"
 />
+
 # String distance
 Another simple way to measure similarity is by computing a string edit distance like Levenshtein distance. You can use the `"string_distance"` evaluator ([reference](https://api.python.langchain.com/en/latest/evaluation/langchain.evaluation.string_distance.base.StringDistanceEvalChain.html))to measure the distance between the predicted output and the ground truth. This depends on the `rapidfuzz` library.
 <CodeTabs

--- a/docs/monitoring/faq/online_evaluation.mdx
+++ b/docs/monitoring/faq/online_evaluation.mdx
@@ -35,7 +35,7 @@ You can choose any model available in the dropdown.
 
 You can customize the prompt template to be whatever you want.
 The prompt template is a LangChain prompt template - this means that anything in `{...}` is treated as a variable to format.
-There are two permitted variables: `inputs` and `outputs`, corresponding to the inputs and outputs of the run you are evaluating
+There are two permitted variables: `input` and `output`, corresponding to the input and output of the run you are evaluating
 
 ### The criteria
 

--- a/docs/tracing/concepts.mdx
+++ b/docs/tracing/concepts.mdx
@@ -38,7 +38,7 @@ Feedback can currently be continuous or discrete (categorical), and you can reus
 Collecting feedback on runs can be done in three main ways:
 1. [In the UI](faq/logging_feedback#annotating-traces-with-feedback) - Annotate runs directly in the UI
 2. [With the SDK](faq/logging_feedback#capturing-feedback-programmatically) - Programmatically log feedback to LangSmith
-3. [With Online Evaluators](/monitoring/faq/online_evaluation) - Automatically run evaluators on a sample of your production traces to generate feeedback in realtime
+3. [With Online Evaluators](/monitoring/faq/online_evaluation) - Automatically run evaluators on a sample of your production traces to generate feedback in realtime
 
 ![Feedback](static/concepts/feedback.png)
 

--- a/docs/tracing/faq/langchain_specific_guides.mdx
+++ b/docs/tracing/faq/langchain_specific_guides.mdx
@@ -188,7 +188,7 @@ This tactic is also useful for when you have multiple chains running in a shared
 
 ### Ensuring all traces are submitted before exiting
 
-In LangChain Python, LangSmith's tracing is done in a background thread to avoid obstructing your production application. This means that if you're process may end before all traces are successfully posted to LangSmith. This is especially prevelant in a serverless environment, where your VM may be terminated immediately once your chain or agent completes.
+In LangChain Python, LangSmith's tracing is done in a background thread to avoid obstructing your production application. This means that your process may end before all traces are successfully posted to LangSmith. This is especially prevalent in a serverless environment, where your VM may be terminated immediately once your chain or agent completes.
 
 In LangChain JS, the default is to block for a short period of time for the trace to finish due to the greater popularity of serverless environments. You can make callbacks asynchronous by setting the `LANGCHAIN_CALLBACKS_BACKGROUND` environment variable to `"true"`.
 

--- a/docs/tracing/faq/logging_feedback.mdx
+++ b/docs/tracing/faq/logging_feedback.mdx
@@ -68,11 +68,11 @@ LangSmith allows you to manually annotate traces with feedback within the applic
 You can annotate a trace either inline or by sending the trace to an Annotation Queue, which allows you closely inspect and log feedbacks to runs one at a time.
 Feedback tags are associated with your tenant.
 
-You can click the top righ corner of the trace to annotate it inline
+You can click the top right corner of the trace to annotate it inline
 ![Annotate Inline](../static/faq/annotate_inline.png)
 
 Or you can send the trace to the Annotation Queue
 ![Send to Queue](../static/faq/send_to_annotation_queue.png)
 
-You can annotate the trace an Annotation Queue using one of the feedback tags associated with your tenant (or create a new one)
+You can annotate the trace in an Annotation Queue using one of the feedback tags associated with your tenant (or create a new one)
 ![Annotation In Queue](../static/faq/annotate_in_queue.png)


### PR DESCRIPTION
Fixes some typos and formatting issues:
* https://docs.smith.langchain.com/monitoring/faq/online_evaluation#the-prompt-template says inputs and outputs but they’re singular in the screenshot
* https://docs.smith.langchain.com/evaluation/faq/evaluator-implementations#no-labels-criteria-evaluation ## Criteria with labels header has actual hashes and URL reference is broken, same with String distance section