### PR TITLE
Trace pages: Add explanation for @traceable and RunTree, move LangCha…

### DIFF
--- a/docs/tracing/faq/customizing_trace_attributes.mdx
+++ b/docs/tracing/faq/customizing_trace_attributes.mdx
@@ -30,26 +30,6 @@ When global environment variables are too broad, you can also set the project na
 
 <CodeTabs
   tabs={[
-    LangChainPyBlock(`# You can set the project name for a specific tracer instance:
-from langchain.callbacks.tracers import LangChainTracer\n
-tracer = LangChainTracer(project_name="My Project")
-chain.invoke({"query": "How many people live in canada as of 2023?"}, config={"callbacks": [tracer]})\n\n
-# LangChain python also supports a context manager for tracing a specific block of code.
-# You can set the project name using the project_name parameter.
-from langchain_core.tracers.context import tracing_v2_enabled
-with tracing_v2_enabled(project_name="My Project"):
-    chain.invoke({"query": "How many people live in canada as of 2023?"})
-`),
-    LangChainJSBlock(`// You can set the project name for a specific tracer instance:
-import { LangChainTracer } from "langchain/callbacks";\n
-const tracer = new LangChainTracer({ projectName: "My Project" });
-await chain.invoke(
-  {
-    query: "How many people live in canada as of 2023?"
-  },
-  { callbacks: [tracer] }
-);
-`),
     PythonBlock(`import openai
 from langsmith import traceable
 from langsmith.run_trees import RunTree\n
@@ -58,23 +38,7 @@ messages = [
     {"role": "system", "content": "You are a helpful assistant."},
     {"role": "user", "content": "Hello!"}
 ]\n
-# Create a RunTree object
-# You can set the project name using the project_name parameter
-rt = RunTree(
-    run_type="llm",
-    name="OpenAI Call RunTree",
-    inputs={"messages": messages},
-    # highlight-next-line
-    project_name="My Project"
-)
-chat_completion = client.chat.completions.create(
-    model="gpt-3.5-turbo",
-    messages=messages,
-)
-# End and submit the run
-rt.end(outputs=chat_completion)
-rt.post()\n
-# You can also use the @traceable decorator to log traces to LangSmith
+# Use the @traceable decorator with the 'project_name' parameter to log traces to LangSmith
 # Ensure that the LANGCHAIN_TRACING_V2 environment variables are set for @traceable to work
 @traceable(
     run_type="llm",
@@ -94,7 +58,7 @@ call_openai(
     langsmith_extra={"project_name": "My Project"},
 )\n
 # The wrapped OpenAI client accepts all the same langsmith_extra parameters
-# as @traceable decorated functions
+# as @traceable decorated functions, and logs traces to langsmith automatically
 from langsmith import wrappers
 wrapped_client = wrappers.wrap_openai(client)
 wrapped_client.chat.completions.create(
@@ -102,7 +66,23 @@ wrapped_client.chat.completions.create(
     messages=messages,
     # highlight-next-line
     langsmith_extra={"project_name": "My Project"},
+)\n\n
+# Alternatively, create a RunTree object
+# You can set the project name using the project_name parameter
+rt = RunTree(
+    run_type="llm",
+    name="OpenAI Call RunTree",
+    inputs={"messages": messages},
+    # highlight-next-line
+    project_name="My Project"
 )
+chat_completion = client.chat.completions.create(
+    model="gpt-3.5-turbo",
+    messages=messages,
+)
+# End and submit the run
+rt.end(outputs=chat_completion)
+rt.post()
 `),
     TypeScriptBlock(`import OpenAI from "openai";
 import { RunTree } from "langsmith";\n
@@ -127,6 +107,26 @@ const chatCompletion = await client.chat.completions.create({
 // End and submit the run
 rt.end(chatCompletion)
 await rt.postRun()`),
+    LangChainPyBlock(`# You can set the project name for a specific tracer instance:
+from langchain.callbacks.tracers import LangChainTracer\n
+tracer = LangChainTracer(project_name="My Project")
+chain.invoke({"query": "How many people live in canada as of 2023?"}, config={"callbacks": [tracer]})\n\n
+# LangChain python also supports a context manager for tracing a specific block of code.
+# You can set the project name using the project_name parameter.
+from langchain_core.tracers.context import tracing_v2_enabled
+with tracing_v2_enabled(project_name="My Project"):
+    chain.invoke({"query": "How many people live in canada as of 2023?"})
+`),
+    LangChainJSBlock(`// You can set the project name for a specific tracer instance:
+import { LangChainTracer } from "langchain/callbacks";\n
+const tracer = new LangChainTracer({ projectName: "My Project" });
+await chain.invoke(
+  {
+    query: "How many people live in canada as of 2023?"
+  },
+  { callbacks: [tracer] }
+);
+`)
   ]}
   groupId="client-language"
 />
@@ -138,6 +138,79 @@ For more information on metadata and tags, see the [Concepts](/tracing/concepts)
 
 <CodeTabs
   tabs={[
+    PythonBlock(`import openai
+from langsmith import traceable
+from langsmith.run_trees import RunTree\n
+client = openai.Client()\n
+messages = [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "Hello!"}
+]\n
+# Use the @traceable decorator with tags and metadata
+# Ensure that the LANGCHAIN_TRACING_V2 environment variables are set for @traceable to work
+@traceable(
+    run_type="llm",
+    name="OpenAI Call Decorator",
+    # highlight-next-line
+    tags=["my-tag"],
+    # highlight-next-line
+    metadata={"my-key": "my-value"}
+)
+def call_openai(
+    messages: list[dict], model: str = "gpt-3.5-turbo"
+) -> str:
+    return client.chat.completions.create(
+        model=model,
+        messages=messages,
+    ).choices[0].message.content\n
+call_openai(
+    messages,
+    # You can provide tags and metadata at invocation time 
+    # via the langsmith_extra parameter
+    # highlight-next-line
+    langsmith_extra={"tags": ["my-other-tag"], "metadata": {"my-other-key": "my-value"}}
+)\n
+# Alternatively, you can create a RunTree object with tags and metadata
+rt = RunTree(
+    run_type="llm",
+    name="OpenAI Call RunTree",
+    inputs={"messages": messages},
+    # highlight-next-line
+    tags=["my-tag"],
+    # highlight-next-line
+    extra={"metadata": {"my-key": "my-value"}}
+)
+chat_completion = client.chat.completions.create(
+    model="gpt-3.5-turbo",
+    messages=messages,
+)
+# End and submit the run
+rt.end(outputs=chat_completion)
+rt.post()`),
+    TypeScriptBlock(`import OpenAI from "openai";
+import { RunTree } from "langsmith";\n
+const client = new OpenAI();\n
+const messages = [
+    {role: "system", content: "You are a helpful assistant."},
+    {role: "user", content: "Hello!"}
+]\n
+// Create a RunTree object
+const rt = new RunTree({
+    run_type: "llm",
+    name: "OpenAI Call RunTree",
+    inputs: { messages },
+    // highlight-next-line
+    tags: ["my-tag"],
+    // highlight-next-line
+    extra: {metadata: {"my-key": "my-value"}}
+})
+const chatCompletion = await client.chat.completions.create({
+    model: "gpt-3.5-turbo",
+    messages: messages,
+});
+// End and submit the run
+rt.end(chatCompletion)
+await rt.postRun()`),
     LangChainPyBlock(`from langchain_openai import ChatOpenAI
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.output_parsers import StrOutputParser\n
@@ -164,79 +237,6 @@ const outputParser = new StringOutputParser();\n
 const chain = (prompt.pipe(model).pipe(outputParser)).withConfig({"tags": ["top-level-tag"], "metadata": {"top-level-key": "top-level-value"}});\n
 // Tags and metadata can also be passed at runtime
 await chain.invoke({input: "What is the meaning of life?"}, {tags: ["shared-tags"], metadata: {"shared-key": "shared-value"}})`),
-    PythonBlock(`import openai
-from langsmith import traceable
-from langsmith.run_trees import RunTree\n
-client = openai.Client()\n
-messages = [
-    {"role": "system", "content": "You are a helpful assistant."},
-    {"role": "user", "content": "Hello!"}
-]\n
-# Create a RunTree object
-rt = RunTree(
-    run_type="llm",
-    name="OpenAI Call RunTree",
-    inputs={"messages": messages},
-    # highlight-next-line
-    tags=["my-tag"],
-    # highlight-next-line
-    extra={"metadata": {"my-key": "my-value"}}
-)
-chat_completion = client.chat.completions.create(
-    model="gpt-3.5-turbo",
-    messages=messages,
-)
-# End and submit the run
-rt.end(outputs=chat_completion)
-rt.post()\n
-# You can also use the @traceable decorator to log traces to LangSmith
-# Ensure that the LANGCHAIN_TRACING_V2 environment variables are set for @traceable to work
-@traceable(
-    run_type="llm",
-    name="OpenAI Call Decorator",
-    # highlight-next-line
-    tags=["my-tag"],
-    # highlight-next-line
-    metadata={"my-key": "my-value"}
-)
-def call_openai(
-    messages: list[dict], model: str = "gpt-3.5-turbo"
-) -> str:
-    return client.chat.completions.create(
-        model=model,
-        messages=messages,
-    ).choices[0].message.content\n
-call_openai(
-    messages,
-    # You can provide tags and metadata at invocation time 
-    # via the langsmith_extra parameter
-    # highlight-next-line
-    langsmith_extra={"tags": ["my-other-tag"], "metadata": {"my-other-key": "my-value"}}
-)`),
-    TypeScriptBlock(`import OpenAI from "openai";
-import { RunTree } from "langsmith";\n
-const client = new OpenAI();\n
-const messages = [
-    {role: "system", content: "You are a helpful assistant."},
-    {role: "user", content: "Hello!"}
-]\n
-// Create a RunTree object
-const rt = new RunTree({
-    run_type: "llm",
-    name: "OpenAI Call RunTree",
-    inputs: { messages },
-    // highlight-next-line
-    tags: ["my-tag"],
-    // highlight-next-line
-    extra: {metadata: {"my-key": "my-value"}}
-})
-const chatCompletion = await client.chat.completions.create({
-    model: "gpt-3.5-turbo",
-    messages: messages,
-});
-// End and submit the run
-rt.end(chatCompletion)
-await rt.postRun()`),
   ]}
   groupId="client-language"
 />
@@ -247,17 +247,6 @@ When you create a run, you can specify a name for the run. This name is used to 
 
 <CodeTabs
   tabs={[
-    LangChainPyBlock(`# When tracing within LangChain, run names default to the class name of the traced object (e.g., 'ChatOpenAI').
-# (Note: this is not currently supported directly on LLM objects.)
-...
-configured_chain = chain.with_config({"run_name": "MyCustomChain"})
-configured_chain.invoke({"query": "What is the meaning of life?"})`),
-    LangChainJSBlock(`// When tracing within LangChain, run names default to the class name of the traced object (e.g., 'ChatOpenAI').
-// (Note: this is not currently supported directly on LLM objects.)
-...
-const configuredChain = chain.withConfig({ runName: "MyCustomChain" });
-await configuredChain.invoke({query: "What is the meaning of life?"});
-`),
     PythonBlock(`import openai
 from langsmith import traceable
 from langsmith.run_trees import RunTree\n
@@ -266,21 +255,7 @@ messages = [
     {"role": "system", "content": "You are a helpful assistant."},
     {"role": "user", "content": "Hello!"}
 ]\n
-# Create a RunTree object
-rt = RunTree(
-    run_type="llm",
-    # highlight-next-line
-    name="OpenAI Call RunTree",
-    inputs={"messages": messages},
-)
-chat_completion = client.chat.completions.create(
-    model="gpt-3.5-turbo",
-    messages=messages,
-)
-# End and submit the run
-rt.end(outputs=chat_completion)
-rt.post()\n
-# You can also use the @traceable decorator to log traces to LangSmith
+# Use the @traceable decorator with the name parameter
 # Ensure that the LANGCHAIN_TRACING_V2 environment variables are set for @traceable to work
 @traceable(
     run_type="llm",
@@ -294,7 +269,21 @@ def call_openai(
         model=model,
         messages=messages,
     ).choices[0].message.content\n
-call_openai(messages)`),
+call_openai(messages)\n
+# Alternatively, use the name parameter of the RunTree object
+rt = RunTree(
+    run_type="llm",
+    # highlight-next-line
+    name="OpenAI Call RunTree",
+    inputs={"messages": messages},
+)
+chat_completion = client.chat.completions.create(
+    model="gpt-3.5-turbo",
+    messages=messages,
+)
+# End and submit the run
+rt.end(outputs=chat_completion)
+rt.post()`),
     TypeScriptBlock(`import OpenAI from "openai";
 import { RunTree } from "langsmith";\n
 const client = new OpenAI();\n
@@ -316,6 +305,17 @@ const chatCompletion = await client.chat.completions.create({
 // End and submit the run
 rt.end(chatCompletion)
 await rt.postRun()`),
+    LangChainPyBlock(`# When tracing within LangChain, run names default to the class name of the traced object (e.g., 'ChatOpenAI').
+# (Note: this is not currently supported directly on LLM objects.)
+...
+configured_chain = chain.with_config({"run_name": "MyCustomChain"})
+configured_chain.invoke({"query": "What is the meaning of life?"})`),
+    LangChainJSBlock(`// When tracing within LangChain, run names default to the class name of the traced object (e.g., 'ChatOpenAI').
+// (Note: this is not currently supported directly on LLM objects.)
+...
+const configuredChain = chain.withConfig({ runName: "MyCustomChain" });
+await configuredChain.invoke({query: "What is the meaning of life?"});
+`)
   ]}
   groupId="client-language"
 />
@@ -348,47 +348,6 @@ You can also customize and override this behavior for a given Client instance.  
 
 <CodeTabs
     tabs={[
-        LangChainPyBlock(`from langchain_core.tracers.context import tracing_v2_enabled
-from langchain_openai import ChatOpenAI
-from langsmith import Client\n\n
-def filter_inputs(inputs: dict):
-    # You can define custom filtering here
-    return {}\n\n
-def filter_outputs(outputs: dict):
-    # You can define custom filtering here
-    return {}\n\n
-llm = ChatOpenAI()\n
-# You can configure tracing using the context manager below
-# or by directly creating a LangChainTracer object
-with tracing_v2_enabled(
-    "test-filtering",
-    client=Client(hide_inputs=filter_inputs, hide_outputs=filter_outputs),
-) as cb:
-    llm.invoke("Say foo")
-    # The linked run will have its metadata present, but the inputs will be hidden
-    print(cb.get_run_url())\n
-with tracing_v2_enabled("test-filtering", client=Client()) as cb:
-    llm.invoke("Say bar")
-    # The linked run will not have hidden inputs and outputs
-    print(cb.get_run_url())
-`),
-        LangChainJSBlock(`import { ChatOpenAI } from "@langchain/openai";
-import { LangChainTracer } from "@langchain/core/tracers/tracer_langchain";
-import { Client} from "langsmith";\n
-(async () => {
-    const llm = new ChatOpenAI();
-    const client = new Client({
-        hideInputs: (inputs) => ({}),
-        hideOutputs: (outputs) => ({}),
-    })
-    const tracer = new LangChainTracer({ client });
-    // The traced run will have its metadata present, but the inputs will be hidden
-    await llm.invoke("Say foo", { callbacks: [tracer] });
-    const unfilteredTracer = new LangChainTracer();
-    // The traced run will not have hidden inputs and outputs
-    await llm.invoke("Say bar", { callbacks: [unfilteredTracer] });
-})();
-`),
         PythonBlock(`import openai
 from langsmith import Client
 from langsmith.wrappers import wrap_openai\n
@@ -442,6 +401,47 @@ const langsmithClient = new Client({
       { role: "user", content: "Hello!" },
     ],
   });
+})();
+`),
+LangChainPyBlock(`from langchain_core.tracers.context import tracing_v2_enabled
+from langchain_openai import ChatOpenAI
+from langsmith import Client\n\n
+def filter_inputs(inputs: dict):
+    # You can define custom filtering here
+    return {}\n\n
+def filter_outputs(outputs: dict):
+    # You can define custom filtering here
+    return {}\n\n
+llm = ChatOpenAI()\n
+# You can configure tracing using the context manager below
+# or by directly creating a LangChainTracer object
+with tracing_v2_enabled(
+    "test-filtering",
+    client=Client(hide_inputs=filter_inputs, hide_outputs=filter_outputs),
+) as cb:
+    llm.invoke("Say foo")
+    # The linked run will have its metadata present, but the inputs will be hidden
+    print(cb.get_run_url())\n
+with tracing_v2_enabled("test-filtering", client=Client()) as cb:
+    llm.invoke("Say bar")
+    # The linked run will not have hidden inputs and outputs
+    print(cb.get_run_url())
+`),
+        LangChainJSBlock(`import { ChatOpenAI } from "@langchain/openai";
+import { LangChainTracer } from "@langchain/core/tracers/tracer_langchain";
+import { Client} from "langsmith";\n
+(async () => {
+    const llm = new ChatOpenAI();
+    const client = new Client({
+        hideInputs: (inputs) => ({}),
+        hideOutputs: (outputs) => ({}),
+    })
+    const tracer = new LangChainTracer({ client });
+    // The traced run will have its metadata present, but the inputs will be hidden
+    await llm.invoke("Say foo", { callbacks: [tracer] });
+    const unfilteredTracer = new LangChainTracer();
+    // The traced run will not have hidden inputs and outputs
+    await llm.invoke("Say bar", { callbacks: [unfilteredTracer] });
 })();
 `),
 ]}

--- a/docs/tracing/faq/logging_and_viewing.mdx
+++ b/docs/tracing/faq/logging_and_viewing.mdx
@@ -18,6 +18,22 @@ import { AccessRunIdBlock } from "@site/src/components/TracingFaq";
 
 LangSmith makes it easy to log and view traces from your LLM application, regardless of which language or framework you use.
 
+### The `@traceable` decorator
+
+The `@traceable` decorator is a simple way to log traces from the LangSmith Python SDK. Simply decorate any function with `@traceable`, set your
+`LANGCHAIN_API_KEY` and `LANGCHAIN_TRACING_V2='true'`, and the inputs and outputs of that function will be logged to LangSmith as a `Run`. You can [choose
+your desination project](/tracing/faq/customizing_trace_attributes#changing-the-destination-project-at-runtime), [add custom metadata and tags](/tracing/faq/customizing_trace_attributes#adding-metadata-and-tags-to-traces),
+and [customize your run name](/tracing/faq/customizing_trace_attributes#customizing-the-run-name).
+
+Also available is the `wrap_openai` function. This function allows you to wrap your OpenAI client in order to automatically log traces, no decorator necessary - it
+is applied for you, under the hood.
+
+### The `RunTree` API
+
+Another, more explicit way to log traces to LangSmith is via the `RunTree` API. This API allows you more control over your tracing - you can manually 
+create runs and children runs to craft your trace however you like. You still need to set your `LANGCHAIN_API_KEY`, but `LANGCHAIN_TRACING_V2` is not
+necessary for this method.
+
 ### Logging Traces
 
 There are multiple ways to logs traces to LangSmith using the LangSmith SDK or API, OpenAI's Python client, or LangChain.
@@ -31,50 +47,43 @@ To log traces to a different project, see [this section](/tracing/faq/customizin
 :::
 :::note
 Please make sure to set the `LANGCHAIN_API_KEY` environment variable to your API key before running the examples below.
-Additionally, you will need to set `LANGCHAIN_TRACING_V2='true'` if you plan to use either
+Additionally, you will need to set `LANGCHAIN_TRACING_V2='true'` if you plan to use either:
 * LangChain (Python or JS)
 * `@traceable` decorator or `wrap_openai` method in the Python SDK
 :::
 
 <CodeTabs
     tabs={[
-        LangChainPyBlock(`# No extra code is needed to log a trace to LangSmith when using LangChain Python.
-# Just run your LangChain code as you normally would with the LANGCHAIN_TRACING_V2 environment variable set to 'true' and the LANGCHAIN_API_KEY environment variable set to your API key.
-from langchain_openai import ChatOpenAI
-from langchain_core.prompts import ChatPromptTemplate
-from langchain_core.output_parsers import StrOutputParser\n
-prompt = ChatPromptTemplate.from_messages([
-    ("system", "You are a helpful assistant. Please respond to the user's request only based on the given context."),
-    ("user", "Question: {question}\nContext: {context}")
-])
-model = ChatOpenAI(model="gpt-3.5-turbo")
-output_parser = StrOutputParser()\n
-chain = prompt | model | output_parser\n
-question = "Can you summarize this morning's meetings?"
-context = "During this morning's meeting, we solved all world conflict."
-chain.invoke({"question": question, "context": context})`),
-        LangChainJSBlock(`// No extra code is needed to log a trace to LangSmith when using LangChain JS.
-// Just run your LangChain code as you normally would with the LANGCHAIN_TRACING_V2 environment variable set to 'true' and the LANGCHAIN_API_KEY environment variable set to your API key.
-import { ChatOpenAI } from "@langchain/openai";
-import { ChatPromptTemplate } from "@langchain/core/prompts";
-import { StringOutputParser } from "@langchain/core/output_parsers";\n
-const prompt = ChatPromptTemplate.fromMessages([
-["system", "You are a helpful assistant. Please respond to the user's request only based on the given context."],
-["user", "Question: {question}\\nContext: {context}"],
-]);
-const model = new ChatOpenAI({ modelName: "gpt-3.5-turbo" });
-const outputParser = new StringOutputParser();\n
-const chain = prompt.pipe(model).pipe(outputParser);\n
-const question = "Can you summarize this morning's meetings?"
-const context = "During this morning's meeting, we solved all world conflict."
-await chain.invoke({ question: question, context: context });`),
         PythonBlock(`# To run the example below, ensure the environment variable OPENAI_API_KEY is set
 from typing import Any, Iterable
 import openai
 from langsmith import traceable
 from langsmith.run_trees import RunTree
 from langsmith.wrappers import wrap_openai\n
-### OPTION 1: Use RunTree API (more explicit) ###
+### OPTION 1: Use traceable decorator ###
+client = openai.Client()
+@traceable(run_type="tool", name="Retrieve Context")
+def my_tool(question: str) -> str:
+    return "During this morning's meeting, we solved all world conflict."\n
+@traceable(name="Chat Pipeline Traceable")
+def chat_pipeline(question: str):
+    context = my_tool(question)
+    messages = [
+        { "role": "system", "content": "You are a helpful assistant. Please respond to the user's request only based on the given context." },
+        { "role": "user", "content": f"Question: {question}\\nContext: {context}"}
+    ]
+    chat_completion = client.chat.completions.create(
+        model="gpt-3.5-turbo", messages=messages
+    )
+    return chat_completion.choices[0].message.content\n
+chat_pipeline("Can you summarize this morning's meetings?")\n
+### Alternatively, use the wrapped OpenAI client to log traces automatically:
+client = wrap_openai(openai.Client())
+client.chat.completions.create(
+    messages=[{"role": "user", "content": "Hello, world"}],
+    model="gpt-3.5-turbo"
+)\n
+### OPTION 2: Use RunTree API (more explicit) ###
 # This can be a user input to your app
 question = "Can you summarize this morning's meetings?"\n
 # Create a top-level run
@@ -87,7 +96,7 @@ pipeline = RunTree(
 context = "During this morning's meeting, we solved all world conflict."\n
 messages = [
     { "role": "system", "content": "You are a helpful assistant. Please respond to the user's request only based on the given context." },
-    { "role": "user", "content": f"Question: {question}\nContext: {context}"}
+    { "role": "user", "content": f"Question: {question}\\nContext: {context}"}
 ]\n
 # Create a child run
 child_llm_run = pipeline.create_child(
@@ -104,26 +113,7 @@ chat_completion = client.chat.completions.create(
 child_llm_run.end(outputs=chat_completion)
 child_llm_run.post()\n
 pipeline.end(outputs={"answer": chat_completion.choices[0].message.content})
-pipeline.post()\n
-### OPTION 2: Use traceable decorator and OpenAI Client ###
-# Optional: wrap the openai client to add tracing directly
-# This can also be done with a traceable decorator
-client = wrap_openai(openai.Client())\n
-@traceable(run_type="tool", name="Retrieve Context")
-def my_tool(question: str) -> str:
-    return "During this morning's meeting, we solved all world conflict."\n
-@traceable(name="Chat Pipeline Traceable")
-def chat_pipeline(question: str):
-    context = my_tool(question)
-    messages = [
-        { "role": "system", "content": "You are a helpful assistant. Please respond to the user's request only based on the given context." },
-        { "role": "user", "content": f"Question: {question}\nContext: {context}"}
-    ]
-    chat_completion = client.chat.completions.create(
-        model="gpt-3.5-turbo", messages=messages
-    )
-    return chat_completion.choices[0].message.content\n
-chat_pipeline("Can you summarize this morning's meetings?")`),
+pipeline.post()`),
         TypeScriptBlock(`// To run the example below, ensure the environment variable OPENAI_API_KEY is set
 import OpenAI from "openai";
 import { RunTree } from "langsmith";\n
@@ -197,7 +187,7 @@ question = "Can you summarize this morning's meetings?"\n
 context = "During this morning's meeting, we solved all world conflict."
 messages = [
     {"role": "system", "content": "You are a helpful assistant. Please respond to the user's request only based on the given context."},
-    {"role": "user", "content": f"Question: {question}\nContext: {context}"}
+    {"role": "user", "content": f"Question: {question}\\nContext: {context}"}
 ]\n
 # Create parent run
 parent_run_id = uuid4()
@@ -210,7 +200,37 @@ client = openai.Client()
 chat_completion = client.chat.completions.create(model="gpt-3.5-turbo", messages=messages)\n
 # End runs
 patch_run(child_run_id, chat_completion.dict())
-patch_run(parent_run_id, {"answer": chat_completion.choices[0].message.content})`)]}
+patch_run(parent_run_id, {"answer": chat_completion.choices[0].message.content})`),
+LangChainPyBlock(`# No extra code is needed to log a trace to LangSmith when using LangChain Python.
+# Just run your LangChain code as you normally would with the LANGCHAIN_TRACING_V2 environment variable set to 'true' and the LANGCHAIN_API_KEY environment variable set to your API key.
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.output_parsers import StrOutputParser\n
+prompt = ChatPromptTemplate.from_messages([
+    ("system", "You are a helpful assistant. Please respond to the user's request only based on the given context."),
+    ("user", "Question: {question}\nContext: {context}")
+])
+model = ChatOpenAI(model="gpt-3.5-turbo")
+output_parser = StrOutputParser()\n
+chain = prompt | model | output_parser\n
+question = "Can you summarize this morning's meetings?"
+context = "During this morning's meeting, we solved all world conflict."
+chain.invoke({"question": question, "context": context})`),
+        LangChainJSBlock(`// No extra code is needed to log a trace to LangSmith when using LangChain JS.
+// Just run your LangChain code as you normally would with the LANGCHAIN_TRACING_V2 environment variable set to 'true' and the LANGCHAIN_API_KEY environment variable set to your API key.
+import { ChatOpenAI } from "@langchain/openai";
+import { ChatPromptTemplate } from "@langchain/core/prompts";
+import { StringOutputParser } from "@langchain/core/output_parsers";\n
+const prompt = ChatPromptTemplate.fromMessages([
+["system", "You are a helpful assistant. Please respond to the user's request only based on the given context."],
+["user", "Question: {question}\\nContext: {context}"],
+]);
+const model = new ChatOpenAI({ modelName: "gpt-3.5-turbo" });
+const outputParser = new StringOutputParser();\n
+const chain = prompt.pipe(model).pipe(outputParser);\n
+const question = "Can you summarize this morning's meetings?"
+const context = "During this morning's meeting, we solved all world conflict."
+await chain.invoke({ question: question, context: context });`),]}
     groupId="client-language"
 />
 


### PR DESCRIPTION
…in tabs behind SDK, and favor @traceable over RunTree API