### PR TITLE
fix: escape newline in Python code block

### DIFF
--- a/versioned_docs/version-2.0/how_to_guides/tracing/annotate_code.mdx
+++ b/versioned_docs/version-2.0/how_to_guides/tracing/annotate_code.mdx
@@ -147,7 +147,7 @@ def chat_pipeline(question: str):
     context = my_tool(question)
     messages = [
         { "role": "system", "content": "You are a helpful assistant. Please respond to the user's request only based on the given context." },
-        { "role": "user", "content": f"Question: {question}\nContext: {context}"}
+        { "role": "user", "content": f"Question: {question}\\nContext: {context}"}
     ]
     chat_completion = client.chat.completions.create(
         model="gpt-3.5-turbo", messages=messages


### PR DESCRIPTION
Fixes:
```
    { "role": "user", "content": f"Question: {question}
                                 ^
SyntaxError: unterminated string literal (detected at line 18)
```