### PR TITLE
Fix typo in code block language name

### DIFF
--- a/versioned_docs/version-2.0/tutorials/evaluation.mdx
+++ b/versioned_docs/version-2.0/tutorials/evaluation.mdx
@@ -152,7 +152,7 @@ Now that we have a dataset and evaluators, all that we need is our application!
 We will build a simple application that just has a system message with instructions on how to respond and then passes it to the LLM.
 We will build this using the OpenAI SDK directly:
 
-```pyton
+```python
 import openai
 
 openai_client = openai.Client()


### PR DESCRIPTION
## What
This is literally a one-character change. The name `python` was misspelled as `pyton`, which prevented syntax highlighting.