### PR TITLE
Add redirect for old release notes

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -93,8 +93,7 @@
     {
       "source": "/category/release-notes", 
       "destination": "/category/self-hosting"
-    },
-    
+    }
   ],
   "builds": [
     {

--- a/vercel.json
+++ b/vercel.json
@@ -92,7 +92,7 @@
     },
     {
       "source": "/category/release-notes", 
-      "destination": "/category/self-hosting"
+      "destination": "/category/self-hosting/release-notes"
     }
   ],
   "builds": [

--- a/vercel.json
+++ b/vercel.json
@@ -92,7 +92,7 @@
     },
     {
       "source": "/category/release-notes", 
-      "destination": "/category/self-hosting/release-notes"
+      "destination": "/self_hosting/release_notes"
     }
   ],
   "builds": [

--- a/vercel.json
+++ b/vercel.json
@@ -89,7 +89,12 @@
     {
       "source": "/category/proxy/:path*",
       "destination": "/old/category/proxy/:path*"
-    }
+    },
+    {
+      "source": "/category/release-notes", 
+      "destination": "/category/self-hosting"
+    },
+    
   ],
   "builds": [
     {


### PR DESCRIPTION
We have some links out there to release notes that are now broken since the last redesign, adding back in a redirect for this.