### PR TITLE
fix: revert to redoc

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -24,20 +24,6 @@ const config = {
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "throw",
 
-  plugins: [
-    [
-      "@scalar/docusaurus",
-      {
-        label: "LangSmith API Docs",
-        route: "/api-docs",
-        configuration: {
-          spec: {
-            url: "https://api.smith.langchain.com/openapi.json",
-          },
-        },
-      },
-    ],
-  ],
   markdown: {
     mermaid: true,
   },
@@ -129,6 +115,11 @@ const config = {
             href: "https://smith.langchain.com/",
             label: "Go to App",
             position: "right",
+          },
+          {
+            href: "https://api.smith.langchain.com/redoc",
+            label: "Go to API Docs",
+            position: "left",
           },
         ],
       },

--- a/versioned_docs/version-2.0/concepts/tracing/tracing.mdx
+++ b/versioned_docs/version-2.0/concepts/tracing/tracing.mdx
@@ -86,7 +86,7 @@ If you wish to remove a trace from LangSmith sooner than the expiration date, La
 This can be accomplished:
 
 - in the LangSmith UI via the "Delete" option on the Project's overflow menu
-- via the [Delete Tracer Sessions](/api-docs#tag/tracer-sessions/delete/api/v1/sessions) API endpoint
+- via the [Delete Tracer Sessions](https://api.smith.langchain.com/redoc#tag/tracer-sessions/operation/delete_tracer_session_api_v1_sessions__session_id__delete) API endpoint
 - via `delete_project()` (Python) or `deleteProject()` (JS/TS) in the LangSmith SDK
 
 LangSmith does not support self-service deletion of individual traces at this time.

--- a/versioned_docs/version-2.0/how_to_guides/tracing/log_llm_trace.mdx
+++ b/versioned_docs/version-2.0/how_to_guides/tracing/log_llm_trace.mdx
@@ -21,7 +21,7 @@ In order to make the most of this feature, you must log your LLM traces in a spe
 
 :::note
 
-The examples below uses the `traceable` decorator/wrapper to log the model run (which is the recommended approach for Python and JS/TS). However, the same idea applies if you are using the [RunTree](./annotate_code#use-the-runtree-api) or [API](https://docs.smith.langchain.com/api-docs) directly.
+The examples below uses the `traceable` decorator/wrapper to log the model run (which is the recommended approach for Python and JS/TS). However, the same idea applies if you are using the [RunTree](./annotate_code#use-the-runtree-api) or [API](https://api.smith.langchain.com/redoc) directly.
 
 :::
 

--- a/versioned_docs/version-2.0/reference/index.md
+++ b/versioned_docs/version-2.0/reference/index.md
@@ -8,7 +8,7 @@ Technical reference that covers components, APIs, and other aspects of LangSmith
 
 ## API reference
 
-- [LangSmith API Reference](https://docs.smith.langchain.com/api-docs)
+- [LangSmith API Reference](https://api.smith.langchain.com/redoc)
 
 ## SDK reference
 


### PR DESCRIPTION
Scalar doesn't allow setting base api url and infers from docs host url
