### PR TITLE
Add LangGraph Cloud page

### DIFF
--- a/versioned_docs/version-2.0/langgraph_cloud.mdx
+++ b/versioned_docs/version-2.0/langgraph_cloud.mdx
@@ -1,0 +1,10 @@
+---
+sidebar_label: LangGraph Cloud
+---
+
+# LangGraph Cloud
+LangGraph Cloud is a managed service for deploying and hosting LangGraph applications. Deploying applications with LangGraph Cloud shortens the time-to-market for developers. With one click, deploy a production-ready API with built-in persistence for your LangGraph application. LangGraph Cloud APIs are horizontally scalable and deployed with durable storage.
+
+LangGraph Cloud is seamlessly integrated with LangSmith and is accessible from the **Deployments** section in the left-hand navigation bar.
+
+See the official <a href="https://langchain-ai.github.io/langgraph/cloud/" target="_blank">LangGraph Cloud documentation</a> for more details.

--- a/versioned_sidebars/version-2.0-sidebars.json
+++ b/versioned_sidebars/version-2.0-sidebars.json
@@ -58,6 +58,7 @@
         }
       ],
       "link": {"type": "doc", "id": "self_hosting/index"}
-    }
+    },
+    "langgraph_cloud"
   ]
 }


### PR DESCRIPTION
### Summary
Adding a page for LangGraph Cloud that mentions that it's accessible from the `Deployments` section, but links to the official LangGraph Cloud documentation.

### Screenshot
![image](https://github.com/langchain-ai/langsmith-docs/assets/7654246/196d7a7b-c2d8-4521-a7a3-afa8cdf9afa4)
