### PR TITLE
docs: fix rag evaluations typo on Tutorials TOC

### DIFF
--- a/versioned_docs/version-2.0/tutorials/index.md
+++ b/versioned_docs/version-2.0/tutorials/index.md
@@ -7,7 +7,7 @@ New to LangSmith? This is the place to start. Here, you'll find a hands-on intro
 - [Add observability to your LLM application](./tutorials/Developers/observability)
 - [Evaluate your LLM application](./tutorials/Developers/evaluation)
 - [Optimize a classifier](./tutorials/Developers/optimize_classifier)
-- [RAG Evalutations](./tutorials/Developers/rag)
+- [RAG Evaluations](./tutorials/Developers/rag)
 - [Backtesting](./tutorials/Developers/backtesting)
 - [Agent Evaluations](./tutorials/Developers/agents)
 


### PR DESCRIPTION
## Changes

* fix `Evalutations` to `Evaluations` on Tutorials table of contents/toc

![Screenshot 2024-07-02 at 4 55 00 PM](https://github.com/langchain-ai/langsmith-docs/assets/5140156/6b50433e-2f1b-4229-817c-f0693a08d4b8)
