### PR TITLE
Add beta flag to Vercel tracing docs

### DIFF
--- a/versioned_docs/version-2.0/how_to_guides/tracing/trace_with_vercel_ai_sdk.mdx
+++ b/versioned_docs/version-2.0/how_to_guides/tracing/trace_with_vercel_ai_sdk.mdx
@@ -7,6 +7,10 @@ import { CodeTabs } from "@site/src/components/InstructionsWithCode";
 
 # Trace with the Vercel AI SDK (JS/TS only)
 
+:::note beta
+This feature is currently in beta while Vercel rolls out official telemetry support.
+:::
+
 You can use LangSmith to trace runs from the [Vercel AI SDK](https://sdk.vercel.ai/docs/introduction) using
 the special `wrapAISDKModel` method. The important detail is that you must wrap the Vercel model wrapper
 rather than of the top-level `generateText` or `generateStream` calls.


### PR DESCRIPTION
The structure of this method is likely to change once official OTel support drops on Vercel's end and there are a few rough edges in the actual app backend for runs.