### PR TITLE
fix: update guidance on tracing without env var in python

### DIFF
--- a/versioned_docs/version-2.0/how_to_guides/index.md
+++ b/versioned_docs/version-2.0/how_to_guides/index.md
@@ -70,7 +70,7 @@ Get started with LangSmith's tracing features to start adding observability to y
   - [Customize run name](./how_to_guides/tracing/trace_with_langchain#customize-run-name)
   - [Access run (span) ID for LangChain invocations](./how_to_guides/tracing/trace_with_langchain#access-run-span-id-for-langchain-invocations)
   - [Ensure all traces are submitted before exiting](./how_to_guides/tracing/trace_with_langchain#ensure-all-traces-are-submitted-before-exiting)
-  - [Trace withouth setting environment variables](./how_to_guides/tracing/trace_with_langchain#trace-without-setting-environment-variables)
+  - [Trace without setting environment variables](./how_to_guides/tracing/trace_with_langchain#trace-without-setting-environment-variables)
   - [Distributed tracing with LangChain (Python)](./how_to_guides/tracing/trace_with_langchain#distributed-tracing-with-langchain-python)
   - [Interoperability between LangChain (Python) and LangSmith SDK](./how_to_guides/tracing/trace_with_langchain#interoperability-between-langchain-python-and-langsmith-sdk)
   - [Interoperability between LangChain.JS and LangSmith SDK](./how_to_guides/tracing/trace_with_langchain#interoperability-between-langchainjs-and-langsmith-sdk)

--- a/versioned_docs/version-2.0/how_to_guides/tracing/annotate_code.mdx
+++ b/versioned_docs/version-2.0/how_to_guides/tracing/annotate_code.mdx
@@ -268,7 +268,7 @@ await pipeline.postRun();`),
 
 In Python, you can use the `trace` context manager to log traces to LangSmith. This is useful in situations where:
 
-1. You want to log traces for a specific block of code, without setting an environment variable that would log traces for the entire application.
+1. You want to log traces for a specific block of code.
 2. You want control over the inputs, outputs, and other attributes of the trace.
 3. It is not feasible to use a decorator or wrapper.
 4. Any or all of the above.

--- a/versioned_docs/version-2.0/how_to_guides/tracing/toggle_tracing.mdx
+++ b/versioned_docs/version-2.0/how_to_guides/tracing/toggle_tracing.mdx
@@ -9,9 +9,10 @@ This section is only relevant for users who are
 
 - [Using `@traceable`/`traceable`](./annotate_code#use-traceable--traceable)
 - [Wrapping the OpenAI client](./annotate_code#wrap-the-openai-client)
+- [Using the `trace` environment variable](./annotate_code#use-the-trace-context-manager-python-only)
 - Using LangChain
 
 :::
 
 If you've decided you no longer want to trace your runs, you can unset the `LANGCHAIN_TRACING_V2` environment variable. Traces will no longer be logged to LangSmith.
-Note that this currently does not affect the `RunTree` objects or API users.
+Note that this currently does not affect the `RunTree` objects or API users, as these are meant to be low-level and not affected by the tracing toggle.

--- a/versioned_docs/version-2.0/how_to_guides/tracing/trace_without_env_vars.mdx
+++ b/versioned_docs/version-2.0/how_to_guides/tracing/trace_without_env_vars.mdx
@@ -4,6 +4,7 @@ sidebar_position: 18
 
 import {
   CodeTabs,
+  PythonBlock,
   typescript,
   python,
 } from "@site/src/components/InstructionsWithCode";
@@ -20,46 +21,47 @@ As mentioned in other guides, the following environment variables allow you to c
 
 In some environments, it is not possible to set environment variables. In these cases, you can set the tracing configuration programmatically.
 
+:::caution Recently changed behavior
+Due to a number of asks for finer-grained control of tracing using the `trace` context manager,
+**we changed the behavior** of `with trace` to honor the `LANGCHAIN_TRACING_V2` environment variable in version **0.1.95** of the Python SDK. You can find more details in the [release notes](https://github.com/langchain-ai/langsmith-sdk/releases/tag/v0.1.95).
+The recommended way to disable/enable tracing without setting environment variables is to use the `with tracing_context` context manager, as shown in the example below.
+:::
+
 <CodeTabs
   tabs={[
-    python({
-      caption:
-        "The recommended way to do this in Python is to use the [`trace` context manager](./annotate_code#use-the-trace-context-manager-python-only) and pass in a configured `langsmith.Client` object.",
-    })`
-        import openai
-        from langsmith import trace
-        from langsmith import Client, traceable
-        from langsmith.wrappers import wrap_openai
-        
-        langsmith_client = Client(
-            api_key="YOUR_API_KEY",  # This can be retrieved from a secrets manager
-            api_url="https://api.smith.langchain.com",  # Update appropriately for self-hosted installations or the EU region
-        )
-        
-        client = wrap_openai(openai.Client())
-        
-        @traceable(run_type="tool", name="Retrieve Context")
-        def my_tool(question: str) -> str:
-            return "During this morning's meeting, we solved all world conflict."
-        
-        def chat_pipeline(question: str):
-            context = my_tool(question)
-            messages = [
-                { "role": "system", "content": "You are a helpful assistant. Please respond to the user's request only based on the given context." },
-                { "role": "user", "content": f"Question: {question}\nContext: {context}"}
-            ]
-            chat_completion = client.chat.completions.create(
-                model="gpt-3.5-turbo", messages=messages
-            )
-            return chat_completion.choices[0].message.content
-        
-        app_inputs = {"input": "Can you summarize this morning's meetings?"}
-        
-        # highlight-next-line
-        with trace("Chat Pipeline", "chain", project_name="test-no-env", inputs=app_inputs, client=langsmith_client) as rt:
-            output = chat_pipeline("Can you summarize this morning's meetings?")
-            rt.end(outputs={"output": output})
-    `,
+    PythonBlock(
+      `import openai
+from langsmith import Client, tracing_context, traceable
+from langsmith.wrappers import wrap_openai\n
+langsmith_client = Client(
+    api_key="YOUR_LANGSMITH_API_KEY",  # This can be retrieved from a secrets manager
+    api_url="https://api.smith.langchain.com",  # Update appropriately for self-hosted installations or the EU region
+)\n
+client = wrap_openai(openai.Client())\n
+@traceable(run_type="tool", name="Retrieve Context")
+def my_tool(question: str) -> str:
+    return "During this morning's meeting, we solved all world conflict."\n
+@traceable
+def chat_pipeline(question: str):
+    context = my_tool(question)
+    messages = [
+        { "role": "system", "content": "You are a helpful assistant. Please respond to the user's request only based on the given context." },
+        { "role": "user", "content": f"Question: {question}\nContext: {context}"}
+    ]
+    chat_completion = client.chat.completions.create(
+        model="gpt-3.5-turbo", messages=messages
+    )
+    return chat_completion.choices[0].message.content\n
+# highlight-next-line
+# Can set to False to disable tracing here without changing code structure
+# highlight-next-line
+with tracing_context(enabled=True):
+    # highlight-next-line
+    # Use langsmith_extra to pass in a custom client
+    # highlight-next-line
+    chat_pipeline("Can you summarize this morning's meetings?", langsmith_extra={"client": langsmith_client})`,
+      "The recommended way to do this in Python is to use the `tracing_context` context manager. This works for both code annotated with `traceable` and code within the `trace` context manager."
+    ),
     typescript({
       caption:
         "In TypeScript, you can pass in both the client and the `tracingEnabled` flag to the `traceable` decorator.",


### PR DESCRIPTION
0.1.95 made `trace` respect the `LANGCHAIN_TRACING_V2` env var