### PR TITLE
docs: add clone dataset command to rag evaluation tutorial

### DIFF
--- a/versioned_docs/version-2.0/tutorials/Developers/rag.mdx
+++ b/versioned_docs/version-2.0/tutorials/Developers/rag.mdx
@@ -38,6 +38,13 @@ _set_env("LANGCHAIN_API_KEY")
 
 ```python
 ### Dataset name
+
+# Clone dataset
+client = Client()
+dataset = client.clone_public_dataset(
+    "https://smith.langchain.com/public/730d833b-74da-43e2-a614-4e2ca2502606/d"
+)
+
 dataset_name = "LCEL-QA"
 ```
 


### PR DESCRIPTION
While following the RAG evaluation page and doing the tutorial, I got an error `LangSmithNotFoundError: Dataset LCEL-QA not found`.

Since it is necessary to clone the LCEL-QA dataset beforehand in order to use it, I added a command of cloning dataset to the sample code.

Probably related to the following issue: https://github.com/langchain-ai/langsmith-docs/issues/297