### PR TITLE
feat: change log level in langsmith python package

### DIFF
--- a/docs/evaluation/how_to_guides/index.md
+++ b/docs/evaluation/how_to_guides/index.md
@@ -41,6 +41,7 @@ Evaluate and improve your application before deploying it.
 
 - [Evaluate with repetitions](./how_to_guides/repetition)
 - [Handle model rate limits](./how_to_guides/rate_limiting)
+- [Print more detailed error messages during evaluation (Python Only)](../../observability/how_to_guides/tracing/output_detailed_logs)
 
 ## Unit testing
 

--- a/docs/evaluation/how_to_guides/index.md
+++ b/docs/evaluation/how_to_guides/index.md
@@ -41,7 +41,7 @@ Evaluate and improve your application before deploying it.
 
 - [Evaluate with repetitions](./how_to_guides/repetition)
 - [Handle model rate limits](./how_to_guides/rate_limiting)
-- [Print more detailed error messages during evaluation (Python Only)](../../observability/how_to_guides/tracing/output_detailed_logs)
+- [Print detailed logs (Python only)](../../observability/how_to_guides/tracing/output_detailed_logs)
 
 ## Unit testing
 

--- a/docs/observability/how_to_guides/index.md
+++ b/docs/observability/how_to_guides/index.md
@@ -38,6 +38,7 @@ Set up LangSmith tracing to get visibility into your production applications.
 - [Trace JS functions in serverless environments](./how_to_guides/tracing/serverless_environments)
 - [Troubleshoot trace testing](./how_to_guides/tracing/nest_traces)
 - [Upload files with traces](./how_to_guides/tracing/upload_files_with_traces)
+- [Print out logs from the LangSmith package (Python Only)](./how_to_guides/tracing/output_detailed_logs)
 
 ## Tracing projects UI & API
 

--- a/docs/observability/how_to_guides/index.md
+++ b/docs/observability/how_to_guides/index.md
@@ -38,7 +38,7 @@ Set up LangSmith tracing to get visibility into your production applications.
 - [Trace JS functions in serverless environments](./how_to_guides/tracing/serverless_environments)
 - [Troubleshoot trace testing](./how_to_guides/tracing/nest_traces)
 - [Upload files with traces](./how_to_guides/tracing/upload_files_with_traces)
-- [Print out logs from the LangSmith package (Python Only)](./how_to_guides/tracing/output_detailed_logs)
+- [Print out logs from the LangSmith SDK (Python Only)](./how_to_guides/tracing/output_detailed_logs)
 
 ## Tracing projects UI & API
 

--- a/docs/observability/how_to_guides/tracing/output_detailed_logs.mdx
+++ b/docs/observability/how_to_guides/tracing/output_detailed_logs.mdx
@@ -6,17 +6,17 @@ import {
 
 # How to print detailed logs (Python SDK)
 
-The LangSmith package uses python's built in [`logging`](https://docs.python.org/3/library/logging.html) mechanism to output logs
+The LangSmith package uses Python's built in [`logging`](https://docs.python.org/3/library/logging.html) mechanism to output logs
 about its behavior to standard output.
 
 ## Ensure logging is configured
 
 :::note
-By default, jupyter notebooks send logs to standard error instead of standard output, which means your
+By default, Jupyter notebooks send logs to standard error instead of standard output, which means your
 logs will not show up in your notebook cell output unless you configure logging as we do below.
 :::
 
-If logging is not currently configured to send logs to standard output for your python environment, you'll need to explicitly turn it on as follows:
+If logging is not currently configured to send logs to standard output for your Python environment, you'll need to explicitly turn it on as follows:
 
 <CodeTabs
   groupId="client-language"

--- a/docs/observability/how_to_guides/tracing/output_detailed_logs.mdx
+++ b/docs/observability/how_to_guides/tracing/output_detailed_logs.mdx
@@ -1,0 +1,48 @@
+import {
+  CodeTabs,
+  PythonBlock,
+  TypeScriptBlock,
+} from "@site/src/components/InstructionsWithCode";
+
+# How to print out logs from the langsmith python package
+
+The LangSmith package uses python's built in [`logging`](https://docs.python.org/3/library/logging.html) mechanism to output logs
+about its behavior to standard output.
+
+## Ensure logging is configured
+
+If logging is not currently configured for your python environment, you'll need to explicitly turn it on as follows:
+
+<CodeTabs
+  groupId="client-language"
+  tabs={[
+    PythonBlock(`
+import logging
+# Note: this will affect _all_ packages that use python's built-in logging mechanism, 
+#       so may increase your log volume. Pick the right log level for your use case.
+logging.basicConfig(level=logging.WARNING)
+    `),
+  ]}
+/>
+
+## Increase the logger's verbosity
+
+When debugging an issue, it's helpful to increase logs to a higher level verbosity so more info is
+outputted to the console. You can set the level to `INFO` or `DEBUG` to get more logs as follows:
+
+<CodeTabs
+  groupId="client-language"
+  tabs={[
+    PythonBlock(`
+import langsmith
+import logging
+
+# Loggers are hierarchical, so setting the log level on "langsmith" will
+
+# set it on all modules inside the "langsmith" package
+
+langsmith_logger = logging.getLogger("langsmith")
+langsmith_logger.setLevel(level=logging.DEBUG)
+`),
+]}
+/>

--- a/docs/observability/how_to_guides/tracing/output_detailed_logs.mdx
+++ b/docs/observability/how_to_guides/tracing/output_detailed_logs.mdx
@@ -4,14 +4,19 @@ import {
   TypeScriptBlock,
 } from "@site/src/components/InstructionsWithCode";
 
-# How to print out logs from the langsmith python package
+# How to print detailed logs (Python SDK)
 
 The LangSmith package uses python's built in [`logging`](https://docs.python.org/3/library/logging.html) mechanism to output logs
 about its behavior to standard output.
 
 ## Ensure logging is configured
 
-If logging is not currently configured for your python environment, you'll need to explicitly turn it on as follows:
+:::note
+By default, jupyter notebooks send logs to standard error instead of standard output, which means your
+logs will not show up in your notebook cell output unless you configure logging as we do below.
+:::
+
+If logging is not currently configured to send logs to standard output for your python environment, you'll need to explicitly turn it on as follows:
 
 <CodeTabs
   groupId="client-language"
@@ -28,21 +33,20 @@ logging.basicConfig(level=logging.WARNING)
 ## Increase the logger's verbosity
 
 When debugging an issue, it's helpful to increase logs to a higher level verbosity so more info is
-outputted to the console. You can set the level to `INFO` or `DEBUG` to get more logs as follows:
+outputted to standard output. Python loggers default to using `WARNING` log level, but you can choose
+different values to get different levels of verbosity. The values, from least verbose to most, are `ERROR`,
+`WARNING`, `INFO`, and `DEBUG`. You can set this as follows:
 
 <CodeTabs
   groupId="client-language"
   tabs={[
     PythonBlock(`
 import langsmith
-import logging
-
+import logging\n
 # Loggers are hierarchical, so setting the log level on "langsmith" will
-
 # set it on all modules inside the "langsmith" package
-
 langsmith_logger = logging.getLogger("langsmith")
 langsmith_logger.setLevel(level=logging.DEBUG)
 `),
-]}
+  ]}
 />


### PR DESCRIPTION
Adding docs for already possible behavior to conditionally set the log level for the `langsmith` package

Added the docs in the observability section, but linked to it from both `evaluation` and `observability` how-to guides since it's helpful in both cases. 