### PR TITLE
fix(docs): Update eval docs on caching. LANGSMITH_CACHE_PATH -> LANGS…

### DIFF
--- a/docs/evaluation/concepts/index.mdx
+++ b/docs/evaluation/concepts/index.mdx
@@ -432,5 +432,5 @@ to run at once.
 
 ### Caching
 
-Lastly, you can also cache the API calls made in your experiment by setting the `LANGSMITH_CACHE_PATH` to a valid folder on your device with write access.
+Lastly, you can also cache the API calls made in your experiment by setting the `LANGSMITH_TEST_CACHE` to a valid folder on your device with write access.
 This will cause the API calls made in your experiment to be cached to disk, meaning future experiments that make the same API calls will be greatly sped up.


### PR DESCRIPTION
…MITH_TEST_CACHE

I could not find any other mentions of `LANGSMITH_CACHE_PATH` in the code for the langchain-ai org repos. I do see mentions of `LANGSMITH_TEST_CACHE` when doing a code search.  