### PR TITLE
docs: Fix cache environment variable in Evaluation concepts -> Caching

### DIFF
--- a/docs/evaluation/concepts/index.mdx
+++ b/docs/evaluation/concepts/index.mdx
@@ -432,5 +432,5 @@ to run at once.
 
 ### Caching
 
-Lastly, you can also cache the API calls made in your experiment by setting the `LANGSMITH_CACHE_PATH` to a valid folder on your device with write access.
+Lastly, you can also cache the API calls made in your experiment by setting the `LANGSMITH_TEST_CACHE` to a valid folder on your device with write access.
 This will cause the API calls made in your experiment to be cached to disk, meaning future experiments that make the same API calls will be greatly sped up.


### PR DESCRIPTION
This PR replaces the incorrectly referenced environment variable `LANGSMITH_CACHE_PATH` with `LANGSMITH_TEST_CACHE`