### PR TITLE
docs: Update vercel ai sdk to clarify custom run ids must be uuid

### DIFF
--- a/docs/observability/how_to_guides/trace_with_vercel_ai_sdk.mdx
+++ b/docs/observability/how_to_guides/trace_with_vercel_ai_sdk.mdx
@@ -265,16 +265,18 @@ await generateText({
 ## Customize run ID
 
 You can customize the run ID by passing the `runId` argument to the `AISDKExporter.getSettings()` method. This is especially useful if you want to know the run ID before the run has been completed.
+Note that the run ID has to be a valid UUID.
 
 ```ts
 import { AISDKExporter } from "langsmith/vercel";
+import { v4 as uuidv4 } from "uuid";
 
 await generateText({
   model: openai("gpt-4o-mini"),
   prompt: "Write a vegetarian lasagna recipe for 4 people.",
   // highlight-start
   experimental_telemetry: AISDKExporter.getSettings({
-    runId: "my-custom-run-id",
+    runId: uuidv4(),
   }),
   // highlight-end
 });


### PR DESCRIPTION
Improve clarity around what format a `runId` can be defined as when using the vercel ai sdk. Currently only UUID is supported.