### PR TITLE
chore: fix CodeTabs not rendering

### DIFF
--- a/docs/evaluation/how_to_guides/fetch_perf_metrics_experiment.mdx
+++ b/docs/evaluation/how_to_guides/fetch_perf_metrics_experiment.mdx
@@ -123,6 +123,7 @@ examples = [
   },
 ]
 client.create_examples(dataset_id=dataset.id, examples=examples)
+```
 
 Next, we will create an experiment, retrieve the experiment name from the result of `evaluate`, then fetch the performance metrics for the experiment.
 


### PR DESCRIPTION
Small fix, a missing ``` is preventing a CodeTabs from rendering correctly.

before:

![old-ls](https://github.com/user-attachments/assets/532a6eb1-219d-43fa-bf03-81f769fa0ede)
 
after:

![new-ls](https://github.com/user-attachments/assets/e39e88a7-4ff8-4bed-84f1-3c0dd264b50d)