### PR TITLE
Fix grammatical error in the Observability docs

### DIFF
--- a/docs/observability/tutorials/observability.mdx
+++ b/docs/observability/tutorials/observability.mdx
@@ -90,7 +90,7 @@ The simple application we're adding observability to looks like:
 
 ## Prototyping
 
-Having observability set up from the start can you help iterate **much** more quickly than you would otherwise be able to.
+Having observability set up from the start can help you iterate **much** more quickly than you would otherwise be able to.
 It allows you to have great visibility into your application as you are rapidly iterating on the prompt, or changing the data and models you are using.
 In this section we'll walk through how to set up observability so you can have maximal observability as you are prototyping.
 


### PR DESCRIPTION
This PR resolves issue #730 

I reordered the sequence "you help" to "help you" which fixes a grammatical error in the `docs/observability/tutorials/observability.mdx` file. 

Are you able to approve this @angus-langchain ?