### PR TITLE
DOCS: docs/self_hosting/installation/kubernetes.mdx: Fix helm install command to include namespace

### DIFF
--- a/docs/self_hosting/installation/kubernetes.mdx
+++ b/docs/self_hosting/installation/kubernetes.mdx
@@ -112,12 +112,12 @@ Ensure you have the following tools/items ready. Some items are marked optional:
         "langchain" has been added to your repositories
 
 :::note Namespace
-If you are using a namespace other than the default namespace, you will need to specify the namespace in the `helm` and `kubectl` commands by using the `-n <namespace` flag.
+If you are using a namespace other than the default namespace, you will need to specify the namespace in the `helm` and `kubectl` commands by using the `-n <namespace>` flag.
 :::
 
-3.  Run `helm install langsmith langchain/langsmith --values langsmith_config.yaml --version <version> --debug`
+3.  Run `helm install langsmith langchain/langsmith --values langsmith_config.yaml --version <version> -n <namespace> --debug`
 
-    - Replace `<your-namespace>` with the namespace you want to deploy LangSmith to.
+    - Replace `<namespace>` with the namespace you want to deploy LangSmith to.
     - Replace `<version>` with the version of LangSmith you want to deploy. You can find the available versions in the [Helm Chart repository](https://github.com/langchain-ai/helm/releases). We generally recommend using the latest version.
       Output should look something like:
 


### PR DESCRIPTION
In `docs/self_hosting/installation/kubernetes.mdx`

The docs mention replacing `<your-namespace>`, but that's not part of the `helm install` command that's shown. Added the namespace argument there and changed the variable to `<namespace>` which seems like more of a style match.

Also fix missing `>` on the earlier mention of `<namespace>`.