### PR TITLE
fix(docs): use run_type instead of runType in TS example

### DIFF
--- a/docs/observability/how_to_guides/log_traces_to_project.mdx
+++ b/docs/observability/how_to_guides/log_traces_to_project.mdx
@@ -123,7 +123,7 @@ const traceableCallOpenAI = traceable(async (messages: {role: string, content: s
 await traceableCallOpenAI(messages, "gpt-4o-mini");\n
 // Create and use a RunTree object
 const rt = new RunTree({
-    runType: "llm",
+    run_type: "llm",
     name: "OpenAI Call RunTree",
     inputs: { messages },
     // highlight-next-line


### PR DESCRIPTION
## 🐛 Fix typo in documentation: `runType` → `run_type`

### What’s changed
- Updated the official documentation example to use `run_type` instead of `runType`, aligning it with the actual interface.

### Why
- The `RunTreeConfig` / `RunTree` interface only permits the `run_type` property, so the discrepancy between the docs and the code causes type errors.

### Notes
- This is a documentation-only change; no additional build or code verification is required.
