### PR TITLE
docs: Added more troubleshooting tips and link to a k8s guide

### DIFF
--- a/docs/self_hosting/troubleshooting.mdx
+++ b/docs/self_hosting/troubleshooting.mdx
@@ -13,6 +13,11 @@ While running LangSmith, you may encounter unexpected 500 errors, slow performan
 ## Getting helpful information
 To diagnose and resolve an issue, you will first need to retrieve some relevant information. Below, we explain how to do this for a kubernetes setup, a docker setup, as well as how to pull helpful browser info.
 
+Generally, the main services you will want to analyze are:
+
+- `langsmith-backend`: The main backend service.
+- `langsmith-queue`: The queue service.
+
 #### Kubernetes
 
 The first step in troubleshooting is to gather important debugging information about your LangSmith deployment. Service logs, kubernetes events, and resource utilization of containers can help identify the root cause of an issue.
@@ -30,11 +35,6 @@ If running on Docker, you can check the logs your deployment by running the foll
 ```bash
 docker compose logs >> logs.txt
 ```
-
-Generally, the main services you will want to analyze are:
-
-- `langsmith-backend`: The main backend service.
-- `langsmith-queue`: The queue service.
 
 #### Browser Errors
 

--- a/docs/self_hosting/troubleshooting.mdx
+++ b/docs/self_hosting/troubleshooting.mdx
@@ -11,6 +11,7 @@ This guide will walk you through common issues you may encounter when running a 
 While running LangSmith, you may encounter unexpected 500 errors, slow performance, or other issues. This guide will help you diagnose and resolve these issues.
 
 ## Getting helpful information
+
 To diagnose and resolve an issue, you will first need to retrieve some relevant information. Below, we explain how to do this for a kubernetes setup, a docker setup, as well as how to pull helpful browser info.
 
 Generally, the main services you will want to analyze are:
@@ -23,10 +24,12 @@ Generally, the main services you will want to analyze are:
 The first step in troubleshooting is to gather important debugging information about your LangSmith deployment. Service logs, kubernetes events, and resource utilization of containers can help identify the root cause of an issue.
 
 You can run our [k8s troubleshooting script](https://github.com/langchain-ai/helm/blob/main/charts/langsmith/scripts/get_k8s_debugging_info.sh) which will pull all of the relevant kubernetes information and output it to a folder for investigation. The script also compresses this folder into a zip file for sharing. Here is an example of how to run this script, assuming your langsmith deployment was brought up in a `langsmith` namespace:
+
 ```bash
 bash get_k8s_debugging_info.sh --namespace langsmith
 ```
-You can then inspect the contents of the produced folder for any relevant errors or information. If you would like the LangSmith team to assist in debugging, please share this zip file with the team. 
+
+You can then inspect the contents of the produced folder for any relevant errors or information. If you would like the LangSmith team to assist in debugging, please share this zip file with the team.
 
 #### Docker
 
@@ -40,7 +43,7 @@ docker compose logs >> logs.txt
 
 If you are experiencing an issue that surfaces as a browser error, it may also be helpful to inspect a HAR file which may include key information. To get the HAR file, you will need to open the developer tools panel in the browser, click into the Network tab, and then download the HAR file locally.
 
-You can then use [Google's HAR analyzer](https://toolbox.googleapps.com/apps/har_analyzer/).   
+You can then use [Google's HAR analyzer](https://toolbox.googleapps.com/apps/har_analyzer/).
 
 ## Common issues
 

--- a/docs/self_hosting/troubleshooting.mdx
+++ b/docs/self_hosting/troubleshooting.mdx
@@ -17,6 +17,7 @@ To diagnose and resolve an issue, you will first need to retrieve some relevant 
 Generally, the main services you will want to analyze are:
 
 - `langsmith-backend`: The main backend service.
+- `langsmith-platform-backend`: Another important backend service.
 - `langsmith-queue`: The queue service.
 
 #### Kubernetes

--- a/docs/self_hosting/troubleshooting.mdx
+++ b/docs/self_hosting/troubleshooting.mdx
@@ -41,9 +41,9 @@ docker compose logs >> logs.txt
 
 #### Browser Errors
 
-If you are experiencing an issue that surfaces as a browser error, it may also be helpful to inspect a HAR file which may include key information. To get the HAR file, you will need to open the developer tools panel in the browser, click into the Network tab, and then download the HAR file locally.
+If you are experiencing an issue that surfaces as a browser error, it may also be helpful to inspect a HAR file which may include key information. To get the HAR file, you can follow [this guide](https://support.zendesk.com/hc/en-us/articles/4408828867098-Generating-a-HAR-file-for-troubleshooting) which explains the short process for various browsers.
 
-You can then use [Google's HAR analyzer](https://toolbox.googleapps.com/apps/har_analyzer/).
+You can then use [Google's HAR analyzer](https://toolbox.googleapps.com/apps/har_analyzer/) to investigate. You can also send your HAR file to the LangSmith team to help with debugging.
 
 ## Common issues
 

--- a/docs/self_hosting/troubleshooting.mdx
+++ b/docs/self_hosting/troubleshooting.mdx
@@ -10,13 +10,20 @@ This guide will walk you through common issues you may encounter when running a 
 
 While running LangSmith, you may encounter unexpected 500 errors, slow performance, or other issues. This guide will help you diagnose and resolve these issues.
 
-The first step in troubleshooting is to check the logs of the various services that make up LangSmith.
+## Getting helpful information
+To diagnose and resolve an issue, you will first need to retrieve some relevant information. Below, we explain how to do this for a kubernetes setup, a docker setup, as well as how to pull helpful browser info.
 
-If running on Kubernetes, you can check the logs of your deployment by running the following command (replace `langsmith` with the name of your deployment if you deployed with a different name):
+#### Kubernetes
 
+The first step in troubleshooting is to gather important debugging information about your LangSmith deployment. Service logs, kubernetes events, and resource utilization of containers can help identify the root cause of an issue.
+
+You can run our [k8s troubleshooting script](https://github.com/langchain-ai/helm/blob/main/charts/langsmith/scripts/get_k8s_debugging_info.sh) which will pull all of the relevant kubernetes information and output it to a folder for investigation. The script also compresses this folder into a zip file for sharing. Here is an example of how to run this script, assuming your langsmith deployment was brought up in a `langsmith` namespace:
 ```bash
-kubectl logs -l app.kubernetes.io/instance=langsmith --prefix -n <namespace> >> logs.txt
+bash get_k8s_debugging_info.sh --namespace langsmith
 ```
+You can then inspect the contents of the produced folder for any relevant errors or information. If you would like the LangSmith team to assist in debugging, please share this zip file with the team. 
+
+#### Docker
 
 If running on Docker, you can check the logs your deployment by running the following command:
 
@@ -28,6 +35,12 @@ Generally, the main services you will want to analyze are:
 
 - `langsmith-backend`: The main backend service.
 - `langsmith-queue`: The queue service.
+
+#### Browser Errors
+
+If you are experiencing an issue that surfaces as a browser error, it may also be helpful to inspect a HAR file which may include key information. To get the HAR file, you will need to open the developer tools panel in the browser, click into the Network tab, and then download the HAR file locally.
+
+You can then use [Google's HAR analyzer](https://toolbox.googleapps.com/apps/har_analyzer/).   
 
 ## Common issues
 


### PR DESCRIPTION
Linking to our new k8s debugger script in our docs. Also, adding a section about getting and analyzing a HAR file for browser errors.

Testing:
Validated the docs page looks as expected here: https://langsmith-docs-gdt6jk87j-langchain.vercel.app/self_hosting/troubleshooting

