### PR TITLE
doc: Update otel page with Hybrid Tracing info

### DIFF
--- a/docs/observability/how_to_guides/trace_langchain_with_otel.mdx
+++ b/docs/observability/how_to_guides/trace_langchain_with_otel.mdx
@@ -10,6 +10,12 @@ This guide covers three core topics:
 
 - Distributed Tracing – Propagate context across services for end-to-end visibility.
 
+:::info
+Since langsmith ≥ 0.4.1,
+setting LANGSMITH_OTEL_ENABLED=true automatically adds a LangSmith OTEL exporter and respects any existing OpenTelemetry TracerProvider or standard OTEL environment variables you configure.
+This means enabling LANGSMITH_OTEL_ENABLED will by default send traces to both LangSmith and your OTEL endpoint (if you have global trace provider initiazlied). No extra code is needed for fan-out.
+:::
+
 ## Sending Traces to LangSmith through OTel
 
 ### 1. Installation
@@ -27,7 +33,7 @@ pip install langchain
 
 ### 2. Enable the OpenTelemetry integration
 
-In LangChain/LangGraph App, you can enable the OpenTelemetry integration by setting the `LANGSMITH_OTEL_ENABLED` environment variable:
+In your LangChain/LangGraph App, enable the OpenTelemetry integration by setting the `LANGSMITH_OTEL_ENABLED` environment variable:
 
 ```bash
 LANGSMITH_OTEL_ENABLED=true
@@ -68,7 +74,7 @@ While LangSmith is the default destination for OpenTelemetry traces, you can als
 
 ### Using Environment Variables or Global Configuration
 
-By default, the LangSmith OpenTelemetry exporter will send data to the LangSmith API OTEL endpoint, but this can be customized by setting standard OTEL environment variables:
+By default, the LangSmith OpenTelemetry exporter will send data to the LangSmith API OTEL endpoint (and to OTEL endpoint as well, if you configured global TracerProvider), but this can be customized by setting standard OTEL environment variables:
 
 ```bash
 OTEL_EXPORTER_OTLP_ENDPOINT: Override the endpoint URL
@@ -80,12 +86,7 @@ LangSmith uses the HTTP trace exporter by default. If you'd like to use your own
 
 1. Set the OTEL environment variables as shown above, or
 2. Set a global trace provider before initializing LangChain components, which LangSmith will detect and use instead of creating its own.
-   :::info
-   Since langsmith ≥ 0.4.1,
-   setting LANGSMITH_OTEL_ENABLED=true automatically adds a LangSmith OTEK exporter and respects any existing OpenTelemetry TracerProvider or standard OTEL environment variables you configure.
 
-This means enabling LANGSMITH_OTEL_ENABLED will by default send traces to both LangSmith and your OTEL enpoint (if you have global trace provider initiazlied). No extra code is needed for fan-out.
-:::
 
 ### Configuring Alternate OTLP Endpoints
 

--- a/docs/observability/how_to_guides/trace_langchain_with_otel.mdx
+++ b/docs/observability/how_to_guides/trace_langchain_with_otel.mdx
@@ -12,8 +12,7 @@ This guide covers three core topics:
 
 :::info
 Since langsmith ≥ 0.4.1,
-setting LANGSMITH_OTEL_ENABLED=true automatically adds a LangSmith OTEL exporter and respects any existing OpenTelemetry TracerProvider or standard OTEL environment variables you configure.
-This means enabling LANGSMITH_OTEL_ENABLED will by default send traces to both LangSmith and your OTEL endpoint (if you have global trace provider initiazlied). No extra code is needed for fan-out.
+setting LANGSMITH_OTEL_ENABLED=true will by default send traces to both LangSmith and your OTEL endpoint (if you have global trace provider initiazlied). No extra code is needed for fan-out.
 :::
 
 ## Sending Traces to LangSmith through OTel
@@ -51,8 +50,6 @@ import os
 from langchain_openai import ChatOpenAI
 from langchain_core.prompts import ChatPromptTemplate
 
-# LangChain will automatically use OpenTelemetry to send traces to LangSmith
-# because the LANGSMITH_OTEL_ENABLED environment variable is set.
 
 # Create a chain
 prompt = ChatPromptTemplate.from_template("Tell me a joke about {topic}")

--- a/docs/observability/how_to_guides/trace_langchain_with_otel.mdx
+++ b/docs/observability/how_to_guides/trace_langchain_with_otel.mdx
@@ -1,8 +1,17 @@
 # Trace LangChain with OpenTelemetry
 
-The LangSmith Python SDK provides built-in OpenTelemetry integration, allowing you to trace your LangChain and LangGraph applications using the OpenTelemetry standard and send those traces to any OTel-compatible platform.
+The LangSmith Python SDK supports OpenTelemetry integration out of the box, letting you trace LangChain and LangGraph apps and export data to LangSmith, to any OTLP-compatible backend, or to both at the same time.
 
-## 1. Installation
+This guide covers three core topics:
+
+- Sending Traces to LangSmith through OTel
+
+- Exporting to OTel-Compatible Providers – Send traces to third-party platforms via the OpenTelemetry Collector.
+
+- Distributed Tracing – Propagate context across services for end-to-end visibility.
+
+## Sending Traces to LangSmith through OTel
+### 1. Installation
 
 :::info
 Requires Python SDK version `langsmith>=0.3.18`.
@@ -15,9 +24,9 @@ pip install "langsmith[otel]"
 pip install langchain
 ```
 
-## 2. Enable the OpenTelemetry integration
+### 2. Enable the OpenTelemetry integration
 
-You can enable the OpenTelemetry integration by setting the `LANGSMITH_OTEL_ENABLED` environment variable:
+In LangChain/LangGraph App, you can enable the OpenTelemetry integration by setting the `LANGSMITH_OTEL_ENABLED` environment variable:
 
 ```bash
 LANGSMITH_OTEL_ENABLED=true
@@ -26,7 +35,7 @@ LANGSMITH_ENDPOINT=https://api.smith.langchain.com
 LANGSMITH_API_KEY=<your_langsmith_api_key>
 ```
 
-## 3. Create a LangChain application with tracing
+###  3. Create a LangChain application with tracing
 
 Here's a simple example showing how to use the OpenTelemetry integration with LangChain:
 
@@ -36,7 +45,7 @@ from langchain_openai import ChatOpenAI
 from langchain_core.prompts import ChatPromptTemplate
 
 # LangChain will automatically use OpenTelemetry to send traces to LangSmith
-# because the LANGSMITH_OTEL_ENABLED environment variable is set
+# because the LANGSMITH_OTEL_ENABLED environment variable is set.
 
 # Create a chain
 prompt = ChatPromptTemplate.from_template("Tell me a joke about {topic}")
@@ -48,9 +57,161 @@ result = chain.invoke({"topic": "programming"})
 print(result.content)
 ```
 
-## 4. View the traces in LangSmith
+###  4. View the traces in LangSmith
 
 Once your application runs, you'll see the traces in your LangSmith dashboard [like this one](https://smith.langchain.com/public/a762af6c-b67d-4f22-90a0-728df16baeba/r).
+
+## Sending Traces to Alternate Providers
+
+While LangSmith is the default destination for OpenTelemetry traces, you can also configure OpenTelemetry to send traces to other observability platforms.
+
+### Using Environment Variables or Global Configuration
+
+By default, the LangSmith OpenTelemetry exporter will send data to the LangSmith API OTEL endpoint, but this can be customized by setting standard OTEL environment variables:
+
+```bash
+OTEL_EXPORTER_OTLP_ENDPOINT: Override the endpoint URL
+OTEL_EXPORTER_OTLP_HEADERS: Add custom headers (LangSmith API keys and Project are added automatically)
+OTEL_SERVICE_NAME: Set a custom service name (defaults to "langsmith")
+```
+
+LangSmith uses the HTTP trace exporter by default. If you'd like to use your own tracing provider, you can either:
+
+1. Set the OTEL environment variables as shown above, or
+2. Set a global trace provider before initializing LangChain components, which LangSmith will detect and use instead of creating its own.
+:::info
+Since langsmith ≥ 0.4.1, 
+setting LANGSMITH_OTEL_ENABLED=true automatically adds a LangSmith OTEK exporter and respects any existing OpenTelemetry TracerProvider or standard OTEL environment variables you configure.
+
+This means enabling LANGSMITH_OTEL_ENABLED will by default send traces to both LangSmith and your OTEL enpoint (if you have global trace provider initiazlied). No extra code is needed for fan-out. 
+:::
+
+### Configuring Alternate OTLP Endpoints
+
+To send traces to a different provider, configure the OTLP exporter with your provider's endpoint:
+
+```python
+import os
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+
+# Set environment variables for LangChain
+os.environ["LANGSMITH_OTEL_ENABLED"] = "true"
+os.environ["LANGSMITH_TRACING"] = "true"
+
+# Configure the OTLP exporter for your custom endpoint
+provider = TracerProvider()
+otlp_exporter = OTLPSpanExporter(
+    # Change to your provider's endpoint
+    endpoint="https://otel.your-provider.com/v1/traces",
+    # Add any required headers for authentication
+    headers={"api-key": "your-api-key"}
+)
+processor = BatchSpanProcessor(otlp_exporter)
+provider.add_span_processor(processor)
+trace.set_tracer_provider(provider)
+
+# Create and run a LangChain application
+prompt = ChatPromptTemplate.from_template("Tell me a joke about {topic}")
+model = ChatOpenAI()
+chain = prompt | model
+
+result = chain.invoke({"topic": "programming"})
+print(result.content)
+```
+:::info
+To disable the hybrid behavior after 0.4.1 and send traces only to your OTEL endpoint and exclude sending to LangSmith, add an additional env var:
+
+LANGSMITH_OTEL_ONLY = "true"
+:::
+
+### Using OpenTelemetry Collector for Fan-out
+
+For more advanced scenarios, you can use the OpenTelemetry Collector to fan out your telemetry data to multiple destinations. This is a more scalable approach than configuring multiple exporters in your application code.
+
+1. **Install the OpenTelemetry Collector**:
+   Follow the [official installation instructions](https://opentelemetry.io/docs/collector/getting-started/) for your environment.
+
+2. **Configure the Collector**:
+   Create a configuration file (e.g., `otel-collector-config.yaml`) that exports to multiple destinations:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  batch:
+
+exporters:
+  otlphttp/langsmith:
+    endpoint: https://api.smith.langchain.com/otel/v1/traces
+    headers:
+      x-api-key: ${env:LANGSMITH_API_KEY}
+      Langsmith-Project: my_project
+
+  otlphttp/other_provider:
+    endpoint: https://otel.your-provider.com/v1/traces
+    headers:
+      api-key: ${env:OTHER_PROVIDER_API_KEY}
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/langsmith, otlphttp/other_provider]
+```
+
+3. **Configure your application to send to the collector**:
+
+```python
+import os
+from opentelemetry import trace
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from langchain_openai import ChatOpenAI
+from langchain_core.prompts import ChatPromptTemplate
+
+# Point to your local OpenTelemetry Collector
+otlp_exporter = OTLPSpanExporter(
+    endpoint="http://localhost:4318/v1/traces"
+)
+
+provider = TracerProvider()
+processor = BatchSpanProcessor(otlp_exporter)
+provider.add_span_processor(processor)
+trace.set_tracer_provider(provider)
+
+# Set environment variables for LangChain
+os.environ["LANGSMITH_OTEL_ENABLED"] = "true"
+os.environ["LANGSMITH_TRACING"] = "true"
+
+# Create and run a LangChain application
+prompt = ChatPromptTemplate.from_template("Tell me a joke about {topic}")
+model = ChatOpenAI()
+chain = prompt | model
+
+result = chain.invoke({"topic": "programming"})
+print(result.content)
+```
+
+This approach offers several advantages:
+
+- Centralized configuration for all your telemetry destinations
+- Reduced overhead in your application code
+- Better scalability and resilience
+- Ability to add or remove destinations without changing application code
+
 
 ## Distributed Tracing with LangChain and OpenTelemetry
 
@@ -139,143 +300,3 @@ def service_b_endpoint():
 if __name__ == "__main__":
     app.run(port=5000)
 ```
-
-## Sending Traces to Alternate Providers
-
-While LangSmith is the default destination for OpenTelemetry traces, you can also configure OpenTelemetry to send traces to other observability platforms.
-
-### Using Environment Variables or Global Configuration
-
-By default, the LangSmith OpenTelemetry exporter will send data to the LangSmith API OTEL endpoint, but this can be customized by setting standard OTEL environment variables:
-
-```bash
-OTEL_EXPORTER_OTLP_ENDPOINT: Override the endpoint URL
-OTEL_EXPORTER_OTLP_HEADERS: Add custom headers (LangSmith API keys and Project are added automatically)
-OTEL_SERVICE_NAME: Set a custom service name (defaults to "langsmith")
-```
-
-LangSmith uses the HTTP trace exporter by default. If you'd like to use your own tracing provider, you can either:
-
-1. Set the OTEL environment variables as shown above, or
-2. Set a global trace provider before initializing LangChain components, which LangSmith will detect and use instead of creating its own.
-
-### Configuring Alternate OTLP Endpoints
-
-To send traces to a different provider, configure the OTLP exporter with your provider's endpoint:
-
-```python
-import os
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from langchain_openai import ChatOpenAI
-from langchain_core.prompts import ChatPromptTemplate
-
-# Set environment variables for LangChain
-os.environ["LANGSMITH_OTEL_ENABLED"] = "true"
-os.environ["LANGSMITH_TRACING"] = "true"
-
-# Configure the OTLP exporter for your custom endpoint
-provider = TracerProvider()
-otlp_exporter = OTLPSpanExporter(
-    # Change to your provider's endpoint
-    endpoint="https://otel.your-provider.com/v1/traces",
-    # Add any required headers for authentication
-    headers={"api-key": "your-api-key"}
-)
-processor = BatchSpanProcessor(otlp_exporter)
-provider.add_span_processor(processor)
-trace.set_tracer_provider(provider)
-
-# Create and run a LangChain application
-prompt = ChatPromptTemplate.from_template("Tell me a joke about {topic}")
-model = ChatOpenAI()
-chain = prompt | model
-
-result = chain.invoke({"topic": "programming"})
-print(result.content)
-```
-
-### Using OpenTelemetry Collector for Fan-out
-
-For more advanced scenarios, you can use the OpenTelemetry Collector to fan out your telemetry data to multiple destinations. This is a more scalable approach than configuring multiple exporters in your application code.
-
-1. **Install the OpenTelemetry Collector**:
-   Follow the [official installation instructions](https://opentelemetry.io/docs/collector/getting-started/) for your environment.
-
-2. **Configure the Collector**:
-   Create a configuration file (e.g., `otel-collector-config.yaml`) that exports to multiple destinations:
-
-```yaml
-receivers:
-  otlp:
-    protocols:
-      grpc:
-        endpoint: 0.0.0.0:4317
-      http:
-        endpoint: 0.0.0.0:4318
-
-processors:
-  batch:
-
-exporters:
-  otlphttp/langsmith:
-    endpoint: https://api.smith.langchain.com/otel/v1/traces
-    headers:
-      x-api-key: ${env:LANGSMITH_API_KEY}
-      Langsmith-Project: my_project
-
-  otlphttp/other_provider:
-    endpoint: https://otel.your-provider.com/v1/traces
-    headers:
-      api-key: ${env:OTHER_PROVIDER_API_KEY}
-
-service:
-  pipelines:
-    traces:
-      receivers: [otlp]
-      processors: [batch]
-      exporters: [otlphttp/langsmith, otlphttp/other_provider]
-```
-
-3. **Configure your application to send to the collector**:
-
-```python
-import os
-from opentelemetry import trace
-from opentelemetry.sdk.trace import TracerProvider
-from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
-from langchain_openai import ChatOpenAI
-from langchain_core.prompts import ChatPromptTemplate
-
-# Point to your local OpenTelemetry Collector
-otlp_exporter = OTLPSpanExporter(
-    endpoint="http://localhost:4318/v1/traces"
-)
-
-provider = TracerProvider()
-processor = BatchSpanProcessor(otlp_exporter)
-provider.add_span_processor(processor)
-trace.set_tracer_provider(provider)
-
-# Set environment variables for LangChain
-os.environ["LANGSMITH_OTEL_ENABLED"] = "true"
-os.environ["LANGSMITH_TRACING"] = "true"
-
-# Create and run a LangChain application
-prompt = ChatPromptTemplate.from_template("Tell me a joke about {topic}")
-model = ChatOpenAI()
-chain = prompt | model
-
-result = chain.invoke({"topic": "programming"})
-print(result.content)
-```
-
-This approach offers several advantages:
-
-- Centralized configuration for all your telemetry destinations
-- Reduced overhead in your application code
-- Better scalability and resilience
-- Ability to add or remove destinations without changing application code

--- a/docs/observability/how_to_guides/trace_langchain_with_otel.mdx
+++ b/docs/observability/how_to_guides/trace_langchain_with_otel.mdx
@@ -11,6 +11,7 @@ This guide covers three core topics:
 - Distributed Tracing – Propagate context across services for end-to-end visibility.
 
 ## Sending Traces to LangSmith through OTel
+
 ### 1. Installation
 
 :::info
@@ -35,7 +36,7 @@ LANGSMITH_ENDPOINT=https://api.smith.langchain.com
 LANGSMITH_API_KEY=<your_langsmith_api_key>
 ```
 
-###  3. Create a LangChain application with tracing
+### 3. Create a LangChain application with tracing
 
 Here's a simple example showing how to use the OpenTelemetry integration with LangChain:
 
@@ -57,7 +58,7 @@ result = chain.invoke({"topic": "programming"})
 print(result.content)
 ```
 
-###  4. View the traces in LangSmith
+### 4. View the traces in LangSmith
 
 Once your application runs, you'll see the traces in your LangSmith dashboard [like this one](https://smith.langchain.com/public/a762af6c-b67d-4f22-90a0-728df16baeba/r).
 
@@ -79,11 +80,11 @@ LangSmith uses the HTTP trace exporter by default. If you'd like to use your own
 
 1. Set the OTEL environment variables as shown above, or
 2. Set a global trace provider before initializing LangChain components, which LangSmith will detect and use instead of creating its own.
-:::info
-Since langsmith ≥ 0.4.1, 
-setting LANGSMITH_OTEL_ENABLED=true automatically adds a LangSmith OTEK exporter and respects any existing OpenTelemetry TracerProvider or standard OTEL environment variables you configure.
+   :::info
+   Since langsmith ≥ 0.4.1,
+   setting LANGSMITH_OTEL_ENABLED=true automatically adds a LangSmith OTEK exporter and respects any existing OpenTelemetry TracerProvider or standard OTEL environment variables you configure.
 
-This means enabling LANGSMITH_OTEL_ENABLED will by default send traces to both LangSmith and your OTEL enpoint (if you have global trace provider initiazlied). No extra code is needed for fan-out. 
+This means enabling LANGSMITH_OTEL_ENABLED will by default send traces to both LangSmith and your OTEL enpoint (if you have global trace provider initiazlied). No extra code is needed for fan-out.
 :::
 
 ### Configuring Alternate OTLP Endpoints
@@ -123,6 +124,7 @@ chain = prompt | model
 result = chain.invoke({"topic": "programming"})
 print(result.content)
 ```
+
 :::info
 To disable the hybrid behavior after 0.4.1 and send traces only to your OTEL endpoint and exclude sending to LangSmith, add an additional env var:
 
@@ -211,7 +213,6 @@ This approach offers several advantages:
 - Reduced overhead in your application code
 - Better scalability and resilience
 - Ability to add or remove destinations without changing application code
-
 
 ## Distributed Tracing with LangChain and OpenTelemetry
 

--- a/docs/observability/how_to_guides/trace_langchain_with_otel.mdx
+++ b/docs/observability/how_to_guides/trace_langchain_with_otel.mdx
@@ -84,7 +84,6 @@ LangSmith uses the HTTP trace exporter by default. If you'd like to use your own
 1. Set the OTEL environment variables as shown above, or
 2. Set a global trace provider before initializing LangChain components, which LangSmith will detect and use instead of creating its own.
 
-
 ### Configuring Alternate OTLP Endpoints
 
 To send traces to a different provider, configure the OTLP exporter with your provider's endpoint:


### PR DESCRIPTION
1. Added "info" banner about Hybrid Tracing
  
  > Since langsmith ≥ 0.4.1, 
  > setting LANGSMITH_OTEL_ENABLED=true automatically adds a LangSmith OTEK exporter and respects any existing OpenTelemetry TracerProvider or standard OTEL environment variables you configure.
  > 
  > This means enabling LANGSMITH_OTEL_ENABLED will by default send traces to both LangSmith and your OTEL enpoint (if you have global trace provider initiazlied). No extra code is needed for fan-out. 
  > 

And 
  > To disable the hybrid behavior after 0.4.1 and send traces only to your OTEL endpoint and exclude sending to LangSmith, add an additional env var:
  > 
  > LANGSMITH_OTEL_ONLY = "true"
  > 

2. This page is pretty long so i added a quick preview
3. I think Distributed Tracing section is an advanced usecase and a less frequent read, so it moved it from section 2 to section 3 the last. 
4. Some nit edits.