### PR TITLE
docs: Link our newly created terraform modules to our LS docs

### DIFF
--- a/docs/self_hosting/installation/kubernetes.mdx
+++ b/docs/self_hosting/installation/kubernetes.mdx
@@ -20,7 +20,7 @@ We've successfully tested LangSmith on the following Kubernetes distributions:
 - OpenShift
 - Minikube and Kind (for development purposes)
 
-:::note
+:::note Terraform modules
 We will be releasing Terraform modules the help in the provisioning of resources for LangSmith. You can find those in our [public Terraform repo](https://github.com/langchain-ai/terraform). For example, you can find a LangSmith module for creating AWS resources in the `modules/aws/langsmith` folder within our public Terraform repo.
 :::
 

--- a/docs/self_hosting/installation/kubernetes.mdx
+++ b/docs/self_hosting/installation/kubernetes.mdx
@@ -20,6 +20,10 @@ We've successfully tested LangSmith on the following Kubernetes distributions:
 - OpenShift
 - Minikube and Kind (for development purposes)
 
+:::note
+We will be releasing Terraform modules the help in the provisioning of resources for LangSmith. You can find those in our [public Terraform repo](https://github.com/langchain-ai/terraform). For example, you can find a LangSmith module for creating AWS resources in the `modules/aws/langsmith` folder within our public Terraform repo.
+:::
+
 ## Prerequisites
 
 Ensure you have the following tools/items ready. Some items are marked optional:


### PR DESCRIPTION
This week we release AWS terraform modules. Lets link those in our LS self hosted installation docs to make installation easier.
