### PR TITLE
Added the URL reference to LangChain Hub

### DIFF
--- a/docs/prompt_engineering/how_to_guides/langchain_hub.mdx
+++ b/docs/prompt_engineering/how_to_guides/langchain_hub.mdx
@@ -4,7 +4,7 @@ sidebar_position: 6
 
 # LangChain Hub
 
-Navigate to the **LangChain Hub** section of the left-hand sidebar.
+Navigate to the [**LangChain Hub**](https://smith.langchain.com/hub) section of the left-hand sidebar.
 
 ![](./static/langchain_hub.png)
 


### PR DESCRIPTION
Resolution for issue https://github.com/langchain-ai/langsmith-docs/issues/854 -

Added the base URL reference for LangChain Hub on the first line of the page.