### PR TITLE
Fix otlphttp endpoint in docs

### DIFF
--- a/docs/observability/how_to_guides/trace_with_opentelemetry.mdx
+++ b/docs/observability/how_to_guides/trace_with_opentelemetry.mdx
@@ -582,13 +582,13 @@ For more advanced scenarios, you can use the OpenTelemetry Collector to fan out 
 
    exporters:
      otlphttp/langsmith:
-       endpoint: https://api.smith.langchain.com/otel/v1/traces
+       endpoint: https://api.smith.langchain.com/otel
        headers:
          x-api-key: ${env:LANGSMITH_API_KEY}
          Langsmith-Project: my_project
 
      otlphttp/other_provider:
-       endpoint: https://otel.your-provider.com/v1/traces
+       endpoint: https://otel.your-provider.com
        headers:
          api-key: ${env:OTHER_PROVIDER_API_KEY}
 


### PR DESCRIPTION
The `otlphttp` endpoint described in the docs here is incorrect, if you attempt to use an OTEL Collector with this endpoint, you'll get this error from your collector:
```2025-07-10T13:44:01.837Z error internal/queue_sender.go:103 Exporting failed. Dropping data. {"kind": "exporter", "data_type": "traces", "name": "otlphttp/langsmith", "error": "not retryable error: Permanent error: rpc error: code = Unimplemented desc = error exporting items, request to [https://api.smith.langchain.com:443/otel/v1/traces/v1/traces](https://api.smith.langchain.com/otel/v1/traces/v1/traces) responded with HTTP Status Code 404", "dropped_items": 1}```

The collector automatically adds the `/v1/traces` for you, so it should not be included in the collector's endpoint config.