### PR TITLE
Remove deprecated off_the_shelf evaluators content

### DIFF
--- a/docs/evaluation/how_to_guides/prebuilt_evaluators.mdx
+++ b/docs/evaluation/how_to_guides/prebuilt_evaluators.mdx
@@ -7,12 +7,11 @@ import {
 # How to use prebuilt evaluators
 
 LangSmith integrates with the open-source [`openevals`](https://github.com/langchain-ai/openevals) package
-to provide a suite of prebuilt, readymade evaluators that you can use right away as starting points for evaluation.
+to provide a suite of prebuilt evaluators that you can use as starting points for evaluation.
 
 
 :::note
-This how-to guide will demonstrate how to set up and run one type of evaluator (LLM-as-a-judge), but there are many others available.
-See the [openevals](https://github.com/langchain-ai/openevals) and [agentevals](https://github.com/langchain-ai/agentevals) repos for a complete list with usage examples.
+This how-to guide will demonstrate how to set up and run one type of evaluator (LLM-as-a-judge). For a complete list of prebuilt evaluators with usage examples, refer to the [openevals](https://github.com/langchain-ai/openevals) and [agentevals](https://github.com/langchain-ai/agentevals) repos.
 :::
 
 ## Setup

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -16,7 +16,6 @@ Technical reference that covers components, APIs, and other aspects of LangSmith
 
 - [Python SDK Reference](https://docs.smith.langchain.com/reference/python)
 - [JS/TS SDK Reference](https://docs.smith.langchain.com/reference/js)
-- [LangChain off-the-shelf evaluators (Python only)](./reference/sdk_reference/langchain_evaluators)
 
 ### Common data types
 

--- a/vercel.json
+++ b/vercel.json
@@ -250,6 +250,14 @@
     {
       "source": "/old/cookbook/introduction/:path*",
       "destination": "/evaluation/concepts"
+    },
+    {
+      "source": "/evaluation/how_to_guides/use_langchain_off_the_shelf_evaluators_old",
+      "destination": "/evaluation/how_to_guides/prebuilt_evaluators"
+    },
+    {
+      "source": "/reference/sdk_reference/langchain_evaluators",
+      "destination": "/evaluation/how_to_guides/prebuilt_evaluators"
     }
   ]
 }


### PR DESCRIPTION
Fixes DOC-29 Removes the deprecated off_the_shelf evaluators content in favor of the `openevals` guide that is currently in the docs for prebuilt evaluators. Redirecting the old content to this prebuilt evaluator guide page for now — this page also contains a link to the GH repo for `openevals` that provides a full list of the prebuilt evals in the README. (For later, decide whether we want to migrate the GH content to the product docs).