### PR TITLE
fix: Typo on Claude Code tracing docs

### DIFF
--- a/docs/observability/how_to_guides/claude_code.mdx
+++ b/docs/observability/how_to_guides/claude_code.mdx
@@ -41,7 +41,7 @@ Claude Code emits [open telemetry standard events](https://docs.anthropic.com/en
 :::
 
 :::note Self-hosted deployments
-If you're self-hosting LangSmith, this feature will be coming soon!
+If you're self-hosting LangSmith, replace the base endpoint with your LangSmith api endpoint and append `/api/v1`. For example: `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=https://ai-company.com/api/v1/otel/v1/claude_code`
 :::
 
 ![Claude Code Trace](./static/claude_code_trace.png)


### PR DESCRIPTION
Also adding a note on how OTEL events are limited in information