### PR TITLE
nit: update labels for LangChain links in footer

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -189,11 +189,11 @@ const config = {
                 href: "https://github.com/langchain-ai/langsmith-sdk",
               },
               {
-                label: "Python",
+                label: "LangChain Python",
                 href: "https://github.com/langchain-ai/langchain",
               },
               {
-                label: "JS/TS",
+                label: "LangChain JS/TS",
                 href: "https://github.com/langchain-ai/langchainjs",
               },
             ],


### PR DESCRIPTION
It's not immediately clear that these are linking to a product that isn't LangSmith