### PR TITLE
Fix bad HTML filtering regexp in build_cookbook.py

### DIFF
--- a/subdirectories/scripts/build_cookbook.py
+++ b/subdirectories/scripts/build_cookbook.py
@@ -433,8 +433,8 @@ We suggest running the code by forking or cloning the repository.
                         parent_dir = os.path.normpath(os.path.dirname(relative_link))
                         return f"]({parent_dir})"
 
-                    # Skip markdown comments
-                    content = re.sub(r"^\s*<!--.*?-->", "", content, flags=re.MULTILINE)
+                    # Skip markdown comments (DOTALL so .*? matches across newlines)
+                    content = re.sub(r"^\s*<!--.*?-->", "", content, flags=re.MULTILINE | re.DOTALL)
                     # Bad sidebar ampersands
                     content = re.sub(
                         r"(^#\s+.*?)(\&amp;)(.*?$)",


### PR DESCRIPTION
## Summary
- Fixes CodeQL alert [py/bad-tag-filter](https://github.com/langchain-ai/langsmith-docs/security/code-scanning) (high severity) in `subdirectories/scripts/build_cookbook.py`
- The regex `re.sub(r"^\s*<!--.*?-->", ...)` used `re.MULTILINE` but not `re.DOTALL`, so `.*?` could not match across newlines — multi-line HTML comments were silently left in place
- Adding `re.DOTALL` makes `.*?` match newline characters, correctly stripping multi-line comments

## Test plan
- [ ] Verify CodeQL alert #6 is resolved after merge
- [ ] Confirm cookbook build still produces expected markdown output

🤖 Generated with [Claude Code](https://claude.com/claude-code)